### PR TITLE
zip icon bug workaround

### DIFF
--- a/app/src/main/java/me/magnum/melonds/common/romprocessors/ZipRomFileProcessor.kt
+++ b/app/src/main/java/me/magnum/melonds/common/romprocessors/ZipRomFileProcessor.kt
@@ -9,6 +9,7 @@ import me.magnum.melonds.domain.model.Rom
 import me.magnum.melonds.domain.model.RomConfig
 import me.magnum.melonds.domain.model.RomInfo
 import me.magnum.melonds.impl.NdsRomCache
+import me.magnum.melonds.utils.RomIconProvider
 import me.magnum.melonds.utils.RomProcessor
 import java.io.*
 import java.util.zip.ZipEntry
@@ -118,7 +119,13 @@ class ZipRomFileProcessor(private val context: Context, private val ndsRomCache:
             } else {
                 val romHash = rom.uri.hashCode().toString()
                 val cachedFile = File(romCacheDir, romHash)
-
+                val iconCacheDir = context.externalCacheDir?.let { File(it, RomIconProvider.ICON_CACHE_DIR) }
+                if (iconCacheDir != null && iconCacheDir.isDirectory) {
+                    val iconFile = File(iconCacheDir, romHash)
+                    if (iconFile.isFile) {
+                        iconFile.delete()
+                    }
+                }
                 context.contentResolver.openInputStream(rom.uri)?.use {
                     val zipStream = ZipInputStream(it)
                     getNdsEntryInStream(zipStream)?.let {

--- a/app/src/main/java/me/magnum/melonds/common/romprocessors/ZipRomFileProcessor.kt
+++ b/app/src/main/java/me/magnum/melonds/common/romprocessors/ZipRomFileProcessor.kt
@@ -9,7 +9,6 @@ import me.magnum.melonds.domain.model.Rom
 import me.magnum.melonds.domain.model.RomConfig
 import me.magnum.melonds.domain.model.RomInfo
 import me.magnum.melonds.impl.NdsRomCache
-import me.magnum.melonds.utils.RomIconProvider
 import me.magnum.melonds.utils.RomProcessor
 import java.io.*
 import java.util.zip.ZipEntry
@@ -119,13 +118,7 @@ class ZipRomFileProcessor(private val context: Context, private val ndsRomCache:
             } else {
                 val romHash = rom.uri.hashCode().toString()
                 val cachedFile = File(romCacheDir, romHash)
-                val iconCacheDir = context.externalCacheDir?.let { File(it, RomIconProvider.ICON_CACHE_DIR) }
-                if (iconCacheDir != null && iconCacheDir.isDirectory) {
-                    val iconFile = File(iconCacheDir, romHash)
-                    if (iconFile.isFile) {
-                        iconFile.delete()
-                    }
-                }
+
                 context.contentResolver.openInputStream(rom.uri)?.use {
                     val zipStream = ZipInputStream(it)
                     getNdsEntryInStream(zipStream)?.let {

--- a/app/src/main/java/me/magnum/melonds/di/MelonModule.kt
+++ b/app/src/main/java/me/magnum/melonds/di/MelonModule.kt
@@ -54,8 +54,8 @@ object MelonModule {
 
     @Provides
     @Singleton
-    fun provideFileRomProcessorFactory(@ApplicationContext context: Context, ndsRomCache: NdsRomCache): RomFileProcessorFactory {
-        return RomFileProcessorFactoryImpl(context, ndsRomCache)
+    fun provideFileRomProcessorFactory(@ApplicationContext context: Context, romIconProvider: dagger.Lazy<RomIconProvider>,ndsRomCache: NdsRomCache): RomFileProcessorFactory {
+        return RomFileProcessorFactoryImpl(context,romIconProvider , ndsRomCache)
     }
 
     @Provides

--- a/app/src/main/java/me/magnum/melonds/impl/RomFileProcessorFactoryImpl.kt
+++ b/app/src/main/java/me/magnum/melonds/impl/RomFileProcessorFactoryImpl.kt
@@ -3,15 +3,23 @@ package me.magnum.melonds.impl
 import android.content.Context
 import android.net.Uri
 import androidx.documentfile.provider.DocumentFile
+import dagger.Lazy
 import me.magnum.melonds.common.romprocessors.RomFileProcessor
 import me.magnum.melonds.common.romprocessors.RomFileProcessorFactory
 import me.magnum.melonds.common.romprocessors.NdsRomFileProcessor
 import me.magnum.melonds.common.romprocessors.ZipRomFileProcessor
+import me.magnum.melonds.utils.RomIconProvider
+import javax.inject.Inject
 
-class RomFileProcessorFactoryImpl(private val context: Context, ndsRomCache: NdsRomCache) : RomFileProcessorFactory {
+
+class RomFileProcessorFactoryImpl(
+        private val context: Context,
+        @Inject val romIconProvider: Lazy<RomIconProvider>,
+        ndsRomCache: NdsRomCache
+)  : RomFileProcessorFactory {
     private val prefixProcessorMap = mapOf(
             "nds" to NdsRomFileProcessor(context),
-            "zip" to ZipRomFileProcessor(context, ndsRomCache)
+            "zip" to ZipRomFileProcessor(context, romIconProvider, ndsRomCache)
     )
 
     override fun getFileRomProcessorForDocument(romDocument: DocumentFile): RomFileProcessor? {

--- a/app/src/main/java/me/magnum/melonds/utils/RomIconProvider.kt
+++ b/app/src/main/java/me/magnum/melonds/utils/RomIconProvider.kt
@@ -58,6 +58,20 @@ class RomIconProvider(private val context: Context, private val romFileProcessor
         return bitmap
     }
 
+    fun reloadIcon(hash: String,rom: Rom) {
+        val iconCacheDir = context.externalCacheDir?.let { File(it, RomIconProvider.ICON_CACHE_DIR) }
+        if (iconCacheDir != null && iconCacheDir.isDirectory) {
+            val iconFile = File(iconCacheDir, hash)
+            if (iconFile.isFile) {
+                iconFile.delete()
+            }
+        }
+
+        var bitmap = loadIconFromDisk(hash, rom)
+        if (bitmap != null)
+            memoryIconCache[hash] = bitmap
+    }
+
     private fun saveRomIcon(romHash: String, icon: Bitmap) {
         val iconCacheDir = context.externalCacheDir?.let { File(it, ICON_CACHE_DIR) } ?: return
         if (iconCacheDir.isDirectory || iconCacheDir.mkdirs()) {


### PR DESCRIPTION
Delete the cached icon when the rom is unzipped so it is correctly drawn using the cached rom when the app is reloaded.
Workaround this #116 