### PR TITLE
Explicitly declare cleartext URL

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">nus.cdn.t.shop.nintendowifi.net</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
DSiWare Manager throws an IOException whenever an installation of DSiWare games is initiated:

```
Process: me.magnum.melonds.dev, PID: 14629
  java.io.IOException: Cleartext HTTP traffic to nus.cdn.t.shop.nintendowifi.net not permitted
  	at com.android.okhttp.HttpHandler$CleartextURLFilter.checkURLPermitted(HttpHandler.java:127)
  	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:462)
  	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:411)
  	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getInputStream(HttpURLConnectionImpl.java:248)
  	at me.magnum.melonds.impl.NusDSiWareMetadataRepository$getDSiWareTitleMetadata$2.invokeSuspend(NusDSiWareMetadataRepository.kt:20)
  	at me.magnum.melonds.impl.NusDSiWareMetadataRepository$getDSiWareTitleMetadata$2.invoke(Unknown Source:8)
  	at me.magnum.melonds.impl.NusDSiWareMetadataRepository$getDSiWareTitleMetadata$2.invoke(Unknown Source:4)
  	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:89)
  	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:169)
  	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source:1)
  	at me.magnum.melonds.impl.NusDSiWareMetadataRepository.getDSiWareTitleMetadata-t3GQkyU(NusDSiWareMetadataRepository.kt:10)
  	at me.magnum.melonds.impl.AndroidDSiNandManager$importTitle$2.invokeSuspend(AndroidDSiNandManager.kt:71)
  	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
  	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
  	at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
  	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
  	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
```

This can be reproduced by running a fresh installation of melonDS, then attempting to run an installation of a DSiWare game through the DSiWare Manager on an empty NAND image, which will always result in a crash, assuming the user is running a platform that prohibits cleartext URL.

Possibly fixes #959 and #1026, but both tickets lacked necessary logs for this to be certain.

Test:
	1. Open DSiWare Manager, attempt to install a DSiWare game (either from ROM list or from file)
	2. The game appears in the list of installed DSiWare games without a crash