### PR TITLE
Exclude DSiWareTitle from ProGuard

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -31,6 +31,7 @@
 -keep class me.magnum.melonds.domain.model.ConsoleType { *; }
 -keep class me.magnum.melonds.domain.model.MicSource { *; }
 -keep class me.magnum.melonds.domain.model.Cheat { *; }
+-keep class me.magnum.melonds.domain.model.DSiWareTitle { *; }
 -keep class me.magnum.melonds.ui.emulator.rewind.model.RewindSaveState { *; }
 -keep class me.magnum.melonds.ui.emulator.rewind.model.RewindWindow { *; }
 -keep class me.magnum.melonds.ui.settings.fragments.**


### PR DESCRIPTION
When compiling melonDS with minify enabled and with the release ProGuard set, it's possible to run into a crash when loading the titles from DSiWare Manager:

```
JNI DETECTED ERROR IN APPLICATION: JNI NewStringUTF called with pending exception java.lang.NoSuchMethodError: no non-static method "Lme/magnum/melonds/domain/model/DSiWareTitle;.<init>(Ljava/lang/String;Ljava/lang/String;J[B)V"
```

Upon further inspection, it seems that a ProGuard rule hasn't yet been made for this model, causing it to be stripped from ProGuard. Exclude this class to ensure the JNI can find it.

Test:
	1. Compile melonDS using the release configuration
	2. Run melonDS, configure the DSi BIOS with a preexisting NAND with at least one DSiWare game installed
	3. No crash in DSiWare Manager is observed