### PR TITLE
Fix target display selection logic in EmulatorActivity

### DIFF
--- a/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
@@ -744,6 +744,8 @@ class EmulatorActivity : AppCompatActivity(), Choreographer.FrameCallback {
         } else {
             displayManager.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION)
                 .firstOrNull { it.displayId != Display.DEFAULT_DISPLAY && it.name != "Built-in Screen" }
+                ?:
+                displayManager.displays.firstOrNull { it.displayId != Display.DEFAULT_DISPLAY }
         }
         if (targetDisplay != null) {
             Log.d(


### PR DESCRIPTION
adds a check that fixed dual screen support for devices using 2 "Built-In Screens" like the OneXSugar.

solution generated by AI.