### PR TITLE
Fix external display detection on some Android devices

### DIFF
--- a/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
@@ -743,7 +743,7 @@ class EmulatorActivity : AppCompatActivity(), Choreographer.FrameCallback {
             displayManager.getDisplay(Display.DEFAULT_DISPLAY)
         } else {
             displayManager.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION)
-                .firstOrNull { it.displayId != Display.DEFAULT_DISPLAY && it.name != "Built-in Screen" }
+                .firstOrNull { it.displayId != Display.DEFAULT_DISPLAY && it.name != "HiddenDisplay" }
         }
         if (targetDisplay != null) {
             Log.d(


### PR DESCRIPTION
this is the fix that is used in the DualScreen port for the OneXSugar and Odin 2. its been tested on there.