### PR TITLE
Improved ROM file matching for external URIs

### DIFF
--- a/app/src/main/java/me/magnum/melonds/impl/FileSystemRomsRepository.kt
+++ b/app/src/main/java/me/magnum/melonds/impl/FileSystemRomsRepository.kt
@@ -101,25 +101,45 @@ class FileSystemRomsRepository(
     }
 
     override suspend fun getRomAtUri(uri: Uri): Rom? {
-        val exactRom = if (uri.authority == EXTERNAL_STORAGE_PROVIDER_AUTHORITY) {
-            getRoms().first().find { rom ->
-                rom.uri == uri
-            }
+        val allRoms = getRoms().first()
+
+        // Quick exact URI match first (no filename needed)
+        allRoms.find { rom -> rom.uri == uri }?.let { return it }
+
+        // Pre-filter by filename for performance
+        val incomingFileName = DocumentFile.fromSingleUri(context, uri)?.name
+        val candidateRoms = if (incomingFileName != null) {
+            allRoms.filter { it.fileName == incomingFileName }
         } else {
-            // Try to find the ROM by obtaining the file path from the URI and checking against known ROMs. This may not always work since there are multiple entry points to
-            // the user-accessible storage (/storage/emulated/0, /mnt/user/0, /sdcard). This can be explored further in the future to see if different path prefixes can be
-            // removed to make this approach more reliable
-            FileUtils.getAbsolutePathFromSingleUri(context, uri)?.let {
-                getRomAtPath(it)
-            }
+            allRoms
         }
 
-        if (exactRom != null)
-            return exactRom
+        // Try to find matching ROM by path, then by size (filename already pre-filtered)
+        val cachedRom = findRomByPath(candidateRoms, uri)
+            ?: findRomBySize(candidateRoms, uri)
+
+        if (cachedRom != null)
+            return cachedRom
 
         // ROM is not known. Create a new ROM from the URI
-        val externalRom = romFileProcessorFactory.getFileRomProcessorForDocument(uri)?.getRomFromUri(uri, null)
-        return externalRom
+        return romFileProcessorFactory.getFileRomProcessorForDocument(uri)?.getRomFromUri(uri, null)
+    }
+
+    private fun findRomByPath(roms: List<Rom>, uri: Uri): Rom? {
+        val incomingPath = FileUtils.getAbsolutePathFromSingleUri(context, uri) ?: return null
+        return roms.find { rom ->
+            FileUtils.getAbsolutePathFromSingleUri(context, rom.uri) == incomingPath
+        }
+    }
+
+    private fun findRomBySize(roms: List<Rom>, uri: Uri): Rom? {
+        val incomingDoc = DocumentFile.fromSingleUri(context, uri)?.takeIf { it.exists() } ?: return null
+        val incomingSize = incomingDoc.length()
+
+        return roms.find { rom ->
+            val romDoc = DocumentFile.fromSingleUri(context, rom.uri)
+            romDoc?.length() == incomingSize
+        }
     }
 
     override fun updateRomConfig(rom: Rom, romConfig: RomConfig) {


### PR DESCRIPTION
I am the developer of [Console Launcher](https://play.google.com/store/apps/details?id=com.k2.consolelauncher), which has an emulation frontend feature on the [Console Launcher GitHub](https://github.com/likeich/console-launcher). Some of my users ran into an issue where MelonDS failed to launch ROMs correctly from Console Launcher.

Console Launcher users often use a feature that generates all emulation platforms from a single folder-for example, a "ROMs" folder is selected that holds NDS, GBA, etc. subfolders with their respective game files. CL detects all of these platforms automatically. This causes an issue with MelonDS when both apps have different scoped storage permissions for the same ROM files.

**The Problem:**
When Console Launcher has access to `/ROMs/` and MelonDS has access to `/ROMs/NDS/`, Android's Storage Access Framework generates different content URIs for the same physical file, even though both point to the same ROM (e.g., `pokemon.nds`). MelonDS previously only performed exact URI matching, which failed when the URIs differed due to different tree root permissions.

This PR fixes this issue by making URI -> Rom matching more robust. First, it utilizes an exact URI check, then a path check, and lastly a file size check. This all is backed by a simple file name filter to reduce slow filesystem calls.

I tested this with CL with the NDS platform set to ROMs (was not working prior-now fixed), CL with the NDS platform set to ROMs/NDS, and with Daijishou.