### PR TITLE
Map phone sleep/wake to DS lid close/open

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
     <uses-feature android:glEsVersion="0x00030000" android:required="true" />
 
@@ -166,6 +167,11 @@
                 android:value="androidx.startup"
                 tools:node="remove" />
         </provider>
+
+        <service
+            android:name=".ui.emulator.LidCloseService"
+            android:foregroundServiceType="mediaPlayback"
+            android:exported="false" />
 
         <service
             android:name="androidx.work.impl.foreground.SystemForegroundService"

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
@@ -7,6 +7,7 @@ import android.hardware.display.DisplayManager
 import android.hardware.input.InputManager
 import android.os.Bundle
 import android.os.Handler
+import android.os.PowerManager
 import android.view.Display
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -186,6 +187,7 @@ class EmulatorActivity : AppCompatActivity() {
     private lateinit var choreographerFrameRenderer: ChoreographerFrameRenderer
     private lateinit var mainScreenRenderer: DSRenderer
     private lateinit var melonTouchHandler: MelonTouchHandler
+    private var lidClosedByScreenOff = false
     private lateinit var nativeInputListener: INativeInputListener
     private val frontendInputHandler = object : FrontendInputHandler() {
         var fastForwardEnabled = false
@@ -684,11 +686,18 @@ class EmulatorActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
+        cancelPendingLidPause()
         choreographerFrameRenderer.startRendering()
 
         if (!activeOverlays.hasActiveOverlays()) {
             disableScreenTimeOut()
             viewModel.resumeEmulator()
+        
+            // Open the virtual lid only if the device actually went to sleep (not on app switch, etc)
+            if (lidClosedByScreenOff) {
+                lidClosedByScreenOff = false
+                melonTouchHandler.setLidClosed(false)
+            }
         }
     }
 
@@ -963,11 +972,38 @@ class EmulatorActivity : AppCompatActivity() {
         viewModel.setSystemOrientation(orientation)
     }
 
+    // Most games play sound for <2secs after closing the lid
+    private val lidClosePauseDelayMs = 3000L
+
+    private val pauseAfterLidCloseRunnable = Runnable {
+        choreographerFrameRenderer.stopRendering()
+        viewModel.pauseEmulator(false)
+        stopService(Intent(this, LidCloseService::class.java))
+    }
+
+    private fun isScreenOff(): Boolean {
+        return getSystemService<PowerManager>()?.isInteractive == false
+    }
+
+    private fun cancelPendingLidPause() {
+        handler.removeCallbacks(pauseAfterLidCloseRunnable)
+        stopService(Intent(this, LidCloseService::class.java))
+    }
+
     override fun onPause() {
         super.onPause()
         enableScreenTimeOut()
-        choreographerFrameRenderer.stopRendering()
-        viewModel.pauseEmulator(false)
+        if (isScreenOff()) {
+            lidClosedByScreenOff = true
+            melonTouchHandler.setLidClosed(true)
+            startForegroundService(Intent(this, LidCloseService::class.java))
+
+            // Delay pausing the emulator just enough to let games play sounds after closing the lid
+            handler.postDelayed(pauseAfterLidCloseRunnable, lidClosePauseDelayMs)
+        } else { // App switch, etc.
+            choreographerFrameRenderer.stopRendering()
+            viewModel.pauseEmulator(false)
+        }
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/LidCloseService.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/LidCloseService.kt
@@ -1,0 +1,30 @@
+package me.magnum.melonds.ui.emulator
+
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import me.magnum.melonds.MelonDSApplication
+
+// Simple service to keep the app in foreground after going to sleep
+// Sound is really crunchy if the app is sent to the background due to Android's handling
+class LidCloseService : Service() {
+    companion object {
+        private const val NOTIFICATION_ID_LID_CLOSE = 300
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val notification = NotificationCompat.Builder(this, MelonDSApplication.NOTIFICATION_CHANNEL_ID_BACKGROUND_TASKS)
+            .setContentTitle("DS Sleep")
+            .setSmallIcon(android.R.drawable.ic_lock_silent_mode)
+            .setSilent(true)
+            .build()
+
+        ServiceCompat.startForeground(this, NOTIFICATION_ID_LID_CLOSE, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+        return START_NOT_STICKY
+    }
+}

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/input/MelonTouchHandler.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/input/MelonTouchHandler.kt
@@ -25,12 +25,18 @@ class MelonTouchHandler : IInputListener {
         MelonEmulator.onScreenTouch(point.x, point.y)
     }
 
-    private fun handleHingePress() {
-        isLidClosed = !isLidClosed
-        if (isLidClosed) {
-            MelonEmulator.onInputDown(Input.HINGE)
-        } else {
-            MelonEmulator.onInputUp(Input.HINGE)
+    fun setLidClosed(closed: Boolean) {
+        if (closed != isLidClosed) {
+            isLidClosed = closed
+            if (isLidClosed) {
+                MelonEmulator.onInputDown(Input.HINGE)
+            } else {
+                MelonEmulator.onInputUp(Input.HINGE)
+            }
         }
+    }
+
+    private fun handleHingePress() {
+        setLidClosed(!isLidClosed)
     }
 }


### PR DESCRIPTION
## Summary

When the phone screen turns off, the DS lid close input is now triggered so the running game can play their sleep sound (if supported) before emulation is paused. 
On screen wake, the lid reopens allowing the game to play their wake sound.

On sleep, games have a 3s window to react on sleep before emulation is paused. There can be slight audio crunchiness during this window because of Android's handling : a service is used to keep the app in foreground which helps a lot.

It is not a necessary feature, but it's fun and makes the experience more immersive, especially on dual-screen handhelds like the Ayn Thor.

## Tested games 

Test devices : Ayn Thor, Samsung Galaxy S23+

Confirmed working with no issues : 

- New Super Mario Bros
- Scribblenauts
- Super Scribblenauts
- Super Mario 64 DS
- Castlevania: Portrait of Ruin
- Transformers: War for Cybertron
- The Legendary Starfy
- Yoshi's Island DS
- Mario vs Donkey Kong Mini-Land Mayhem
- Mario vs Donkey Kong 2 March of the Minis                                    

Full list of known games which play sounds on wake/sleep : https://niwanetwork.org/wiki/Sleep_Mode