### PR TITLE
Added combo hotkeys

### DIFF
--- a/app/src/main/java/me/magnum/melonds/domain/model/InputConfig.kt
+++ b/app/src/main/java/me/magnum/melonds/domain/model/InputConfig.kt
@@ -8,7 +8,10 @@ data class InputConfig(
 
     sealed class Assignment(open val deviceId: Int?) {
         data object None : Assignment(null)
-        data class Key(override val deviceId: Int?, val keyCode: Int) : Assignment(deviceId)
+        data class Key(override val deviceId: Int?, val keyCode: Int, val modifierKeyCodes: List<Int> = emptyList()) : Assignment(deviceId) {
+            val keyCodes: List<Int>
+                get() = modifierKeyCodes + keyCode
+        }
         data class Axis(override val deviceId: Int?, val axisCode: Int, val direction: Direction) : Assignment(deviceId) {
             enum class Direction {
                 POSITIVE,

--- a/app/src/main/java/me/magnum/melonds/impl/dtos/input/InputConfigDto.kt
+++ b/app/src/main/java/me/magnum/melonds/impl/dtos/input/InputConfigDto.kt
@@ -27,6 +27,7 @@ data class InputConfigDto(
         class Key(
             override val deviceId: Int?,
             @SerialName("keyCode") val keyCode: Int,
+            @SerialName("modifierKeyCodes") val modifierKeyCodes: List<Int> = emptyList(),
         ) : AssignmentDto()
 
         @Serializable
@@ -44,12 +45,12 @@ data class InputConfigDto(
                 input = inputConfig.input,
                 assignment = when (inputConfig.assignment) {
                     is InputConfig.Assignment.None -> AssignmentDto.None
-                    is InputConfig.Assignment.Key -> AssignmentDto.Key(inputConfig.assignment.deviceId, inputConfig.assignment.keyCode)
+                    is InputConfig.Assignment.Key -> AssignmentDto.Key(inputConfig.assignment.deviceId, inputConfig.assignment.keyCode, inputConfig.assignment.modifierKeyCodes)
                     is InputConfig.Assignment.Axis -> AssignmentDto.Axis(inputConfig.assignment.deviceId, inputConfig.assignment.axisCode, inputConfig.assignment.direction)
                 },
                 altAssignment = when (inputConfig.altAssignment) {
                     is InputConfig.Assignment.None -> AssignmentDto.None
-                    is InputConfig.Assignment.Key -> AssignmentDto.Key(inputConfig.altAssignment.deviceId, inputConfig.altAssignment.keyCode)
+                    is InputConfig.Assignment.Key -> AssignmentDto.Key(inputConfig.altAssignment.deviceId, inputConfig.altAssignment.keyCode, inputConfig.altAssignment.modifierKeyCodes)
                     is InputConfig.Assignment.Axis -> AssignmentDto.Axis(inputConfig.altAssignment.deviceId, inputConfig.altAssignment.axisCode, inputConfig.altAssignment.direction)
                 }
             )
@@ -61,12 +62,12 @@ data class InputConfigDto(
             input = input,
             assignment = when (assignment) {
                 is AssignmentDto.None -> InputConfig.Assignment.None
-                is AssignmentDto.Key -> InputConfig.Assignment.Key(assignment.deviceId, assignment.keyCode)
+                is AssignmentDto.Key -> InputConfig.Assignment.Key(assignment.deviceId, assignment.keyCode, assignment.modifierKeyCodes)
                 is AssignmentDto.Axis -> InputConfig.Assignment.Axis(assignment.deviceId, assignment.axisCode, assignment.direction)
             },
             altAssignment = when (altAssignment) {
                 is AssignmentDto.None -> InputConfig.Assignment.None
-                is AssignmentDto.Key -> InputConfig.Assignment.Key(altAssignment.deviceId, altAssignment.keyCode)
+                is AssignmentDto.Key -> InputConfig.Assignment.Key(altAssignment.deviceId, altAssignment.keyCode, altAssignment.modifierKeyCodes)
                 is AssignmentDto.Axis -> InputConfig.Assignment.Axis(altAssignment.deviceId, altAssignment.axisCode, altAssignment.direction)
             }
         )

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/input/ConnectedControllerManager.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/input/ConnectedControllerManager.kt
@@ -100,7 +100,7 @@ class ConnectedControllerManager : InputManager.InputDeviceListener {
                         controllerAssignments.any { assignment ->
                             when(assignment) {
                                 is InputConfig.Assignment.Axis -> managedControllers.any { it.getMotionRange(assignment.axisCode) != null }
-                                is InputConfig.Assignment.Key -> managedControllers.any { it.hasKeys(assignment.keyCode)[0] }
+                                is InputConfig.Assignment.Key -> managedControllers.any { it.hasKeys(*assignment.keyCodes.toIntArray()).all { hasKey -> hasKey } }
                                 InputConfig.Assignment.None -> false
                             }
                         }
@@ -147,7 +147,7 @@ class ConnectedControllerManager : InputManager.InputDeviceListener {
                 controllers.any { device ->
                     when (assignment) {
                         is InputConfig.Assignment.Axis -> device.getMotionRange(assignment.axisCode) != null
-                        is InputConfig.Assignment.Key -> device.hasKeys(assignment.keyCode)[0]
+                        is InputConfig.Assignment.Key -> device.hasKeys(*assignment.keyCodes.toIntArray()).all { hasKey -> hasKey }
                         InputConfig.Assignment.None -> false
                     }
                 }

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/input/InputProcessor.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/input/InputProcessor.kt
@@ -4,51 +4,81 @@ import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.MotionEvent
 import me.magnum.melonds.domain.model.ControllerConfiguration
+import me.magnum.melonds.domain.model.Input
 import me.magnum.melonds.domain.model.InputConfig
 import kotlin.math.absoluteValue
 
 class InputProcessor(private val controllerConfiguration: ControllerConfiguration, private val systemInputListener: IInputListener, private val frontendInputListener: IInputListener) : INativeInputListener {
 
     private val axisStates: Map<Axis, AxisState>
+    private val keyCombinations: List<Pair<Input, InputConfig.Assignment.Key>>
+    private val pressedKeys = mutableSetOf<Int>()
+    private val activeKeyCombinations = mutableMapOf<Input, InputConfig.Assignment.Key>()
 
     init {
-        val axis = controllerConfiguration.inputMapper.flatMap { inputConfig ->
+        val assignments = controllerConfiguration.inputMapper.flatMap { inputConfig ->
             listOf(inputConfig.assignment, inputConfig.altAssignment)
-        }.mapNotNull { assignment ->
+                .map { inputConfig.input to it }
+        }
+
+        val axis = assignments.mapNotNull { (_, assignment) ->
             (assignment as? InputConfig.Assignment.Axis)?.let {
                 Axis(it.deviceId, it.axisCode, it.direction)
             }
         }
 
         axisStates = axis.associateWith { AxisState(0f, false) }
+        keyCombinations = assignments.mapNotNull { (input, assignment) ->
+            (assignment as? InputConfig.Assignment.Key)
+                ?.takeIf { it.modifierKeyCodes.isNotEmpty() }
+                ?.let { input to it }
+        }
     }
 
     override fun onKeyEvent(keyEvent: KeyEvent): Boolean {
-        val input = controllerConfiguration.keyToInput(keyEvent.keyCode) ?: return false
-        if (input.isSystemInput) {
-            when (keyEvent.action) {
-                KeyEvent.ACTION_DOWN -> {
-                    systemInputListener.onKeyPress(input)
-                    return true
-                }
-                KeyEvent.ACTION_UP -> {
-                    systemInputListener.onKeyReleased(input)
-                    return true
-                }
-            }
-        } else {
-            when (keyEvent.action) {
-                KeyEvent.ACTION_DOWN -> {
-                    frontendInputListener.onKeyPress(input)
-                    return true
-                }
-                KeyEvent.ACTION_UP -> {
-                    frontendInputListener.onKeyReleased(input)
+        if (keyEvent.action == KeyEvent.ACTION_DOWN && keyEvent.repeatCount > 0 && activeKeyCombinationContains(keyEvent.keyCode)) {
+            return true
+        }
+
+        if (keyEvent.action == KeyEvent.ACTION_DOWN && keyEvent.repeatCount == 0) {
+            pressedKeys.add(keyEvent.keyCode)
+            keyCombinationToInput(keyEvent.deviceId)?.let { (input, assignment) ->
+                if (activeKeyCombinations[input] == null) {
+                    activeKeyCombinations[input] = assignment
+                    dispatchInputPressed(input)
                     return true
                 }
             }
         }
-        return false
+
+        if (keyEvent.action == KeyEvent.ACTION_UP) {
+            val activeCombination = activeKeyCombinations.entries.firstOrNull { (_, assignment) ->
+                assignment.keyCodes.contains(keyEvent.keyCode)
+            }
+
+            if (activeCombination != null) {
+                pressedKeys.remove(keyEvent.keyCode)
+                activeKeyCombinations.remove(activeCombination.key)
+                dispatchInputReleased(activeCombination.key)
+                return true
+            }
+
+            pressedKeys.remove(keyEvent.keyCode)
+        }
+
+        val input = keyToInput(keyEvent.keyCode)
+            ?: return keyIsInCombination(keyEvent.keyCode)
+        when (keyEvent.action) {
+            KeyEvent.ACTION_DOWN -> {
+                dispatchInputPressed(input)
+                return true
+            }
+            KeyEvent.ACTION_UP -> {
+                dispatchInputReleased(input)
+                return true
+            }
+        }
+        return keyIsInCombination(keyEvent.keyCode)
     }
 
     override fun onMotionEvent(motionEvent: MotionEvent): Boolean {
@@ -68,18 +98,10 @@ class InputProcessor(private val controllerConfiguration: ControllerConfiguratio
                     controllerConfiguration.axisToInput(axis.axisCode, axis.direction)?.let { input ->
                         if (axisState.active) {
                             axisState.active = false
-                            if (input.isSystemInput) {
-                                systemInputListener.onKeyReleased(input)
-                            } else {
-                                frontendInputListener.onKeyReleased(input)
-                            }
+                            dispatchInputReleased(input)
                         } else {
                             axisState.active = true
-                            if (input.isSystemInput) {
-                                systemInputListener.onKeyPress(input)
-                            } else {
-                                frontendInputListener.onKeyPress(input)
-                            }
+                            dispatchInputPressed(input)
                         }
                     }
                 }
@@ -107,6 +129,49 @@ class InputProcessor(private val controllerConfiguration: ControllerConfiguratio
             } else {
                 newValue.absoluteValue >= 0.5f
             }
+        }
+    }
+
+    private fun activeKeyCombinationContains(keyCode: Int): Boolean {
+        return activeKeyCombinations.values.any { it.keyCodes.contains(keyCode) }
+    }
+
+    private fun keyCombinationToInput(deviceId: Int?): Pair<Input, InputConfig.Assignment.Key>? {
+        return keyCombinations
+            .filter { (_, assignment) ->
+                (assignment.deviceId == null || assignment.deviceId == deviceId) &&
+                    pressedKeys.containsAll(assignment.keyCodes)
+            }
+            .maxByOrNull { (_, assignment) -> assignment.keyCodes.size }
+    }
+
+    private fun keyIsInCombination(keyCode: Int): Boolean {
+        return keyCombinations.any { (_, assignment) -> assignment.keyCodes.contains(keyCode) }
+    }
+
+    private fun keyToInput(keyCode: Int): Input? {
+        return controllerConfiguration.inputMapper.firstOrNull { config ->
+            listOf(config.assignment, config.altAssignment).any { assignment ->
+                (assignment as? InputConfig.Assignment.Key)?.let {
+                    it.keyCode == keyCode && it.modifierKeyCodes.isEmpty()
+                } == true
+            }
+        }?.input
+    }
+
+    private fun dispatchInputPressed(input: Input) {
+        if (input.isSystemInput) {
+            systemInputListener.onKeyPress(input)
+        } else {
+            frontendInputListener.onKeyPress(input)
+        }
+    }
+
+    private fun dispatchInputReleased(input: Input) {
+        if (input.isSystemInput) {
+            systemInputListener.onKeyReleased(input)
+        } else {
+            frontendInputListener.onKeyReleased(input)
         }
     }
 }

--- a/app/src/main/java/me/magnum/melonds/ui/inputsetup/InputSetupActivity.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/inputsetup/InputSetupActivity.kt
@@ -27,6 +27,8 @@ class InputSetupActivity : AppCompatActivity() {
     private val viewModel: InputSetupViewModel by viewModels()
 
     private val referenceAxisValues = mutableMapOf<Int, Float>()
+    private val pressedKeysUnderAssignment = mutableSetOf<Int>()
+    private val keysToConsumeAfterAssignment = mutableSetOf<Int>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge(
@@ -49,6 +51,8 @@ class InputSetupActivity : AppCompatActivity() {
                     if (it != null) {
                         // A new assignment has started. Reset reference values
                         referenceAxisValues.clear()
+                        pressedKeysUnderAssignment.clear()
+                        keysToConsumeAfterAssignment.clear()
                         InputDevice.getDeviceIds().forEach { deviceId ->
                             InputDevice.getDevice(deviceId)?.motionRanges?.forEach { range ->
                                 if (range.isFromSource(InputDevice.SOURCE_CLASS_JOYSTICK)) {
@@ -94,11 +98,34 @@ class InputSetupActivity : AppCompatActivity() {
     }
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        if (event.action == KeyEvent.ACTION_DOWN && viewModel.inputUnderAssignment.value != null) {
+        if (event.action == KeyEvent.ACTION_UP && keysToConsumeAfterAssignment.remove(event.keyCode)) {
+            return true
+        }
+
+        if (viewModel.inputUnderAssignment.value != null) {
+            if (event.keyCode == KeyEvent.KEYCODE_BACK) {
+                return super.dispatchKeyEvent(event)
+            }
+
             @SuppressLint("GestureBackNavigation")
-            if (event.keyCode != KeyEvent.KEYCODE_BACK) {
-                viewModel.updateInputAssignedKey(event.keyCode)
-                return true
+            when (event.action) {
+                KeyEvent.ACTION_DOWN -> {
+                    if (event.repeatCount == 0) {
+                        pressedKeysUnderAssignment.add(event.keyCode)
+                        if (pressedKeysUnderAssignment.size >= 2) {
+                            keysToConsumeAfterAssignment.addAll(pressedKeysUnderAssignment)
+                            viewModel.updateInputAssignedKeyCombination(pressedKeysUnderAssignment.toList())
+                            pressedKeysUnderAssignment.clear()
+                        }
+                    }
+                    return true
+                }
+                KeyEvent.ACTION_UP -> {
+                    if (pressedKeysUnderAssignment.remove(event.keyCode) && pressedKeysUnderAssignment.isEmpty()) {
+                        viewModel.updateInputAssignedKey(event.keyCode)
+                    }
+                    return true
+                }
             }
         }
         return super.dispatchKeyEvent(event)

--- a/app/src/main/java/me/magnum/melonds/ui/inputsetup/InputSetupViewModel.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/inputsetup/InputSetupViewModel.kt
@@ -40,6 +40,14 @@ class InputSetupViewModel @Inject constructor(private val settingsRepository: Se
         focusOnNextInput(inputUnderAssignment)
     }
 
+    fun updateInputAssignedKeyCombination(keys: List<Int>) {
+        val inputUnderAssignment = _inputUnderAssignment.value ?: return
+        val distinctKeys = keys.distinct()
+        val inputType = InputConfig.Assignment.Key(null, distinctKeys.last(), distinctKeys.dropLast(1))
+        setInputAssignment(inputUnderAssignment, inputType)
+        focusOnNextInput(inputUnderAssignment)
+    }
+
     fun updateInputAssignedAxis(axis: Int, direction: InputConfig.Assignment.Axis.Direction) {
         val inputUnderAssignment = _inputUnderAssignment.value ?: return
         val inputType = InputConfig.Assignment.Axis(null, axis, direction)

--- a/app/src/main/java/me/magnum/melonds/ui/inputsetup/ui/InputSetupScreen.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/inputsetup/ui/InputSetupScreen.kt
@@ -173,8 +173,10 @@ private fun Input(
                     assignments.joinToString(" / ") { assignment ->
                         when (assignment) {
                             is InputConfig.Assignment.Key -> {
-                                val keyCodeString = KeyEvent.keyCodeToString(assignment.keyCode)
-                                keyCodeString.replace("KEYCODE", "").replace("_", " ").trim()
+                                assignment.keyCodes.joinToString(" + ") { keyCode ->
+                                    val keyCodeString = KeyEvent.keyCodeToString(keyCode)
+                                    keyCodeString.replace("KEYCODE", "").replace("_", " ").trim()
+                                }
                             }
                             is InputConfig.Assignment.Axis -> {
                                 val axisString = MotionEvent.axisToString(assignment.axisCode)


### PR DESCRIPTION
Adds support for combination hotkeys (e.g. L3 + A, R3 + B).

Implemented this based on the existing feature request/discussion: https://github.com/rafaelvcaetano/melonDS-android/discussions/1400

This should be helpful not only for controllers without back buttons, but also for keeping keybinds consistent across emulators and enabling better mappings on devices with limited buttons.