### PR TITLE
Added hold to fast forward functionality

### DIFF
--- a/app/src/main/java/me/magnum/melonds/domain/model/ControllerConfiguration.kt
+++ b/app/src/main/java/me/magnum/melonds/domain/model/ControllerConfiguration.kt
@@ -18,6 +18,7 @@ class ControllerConfiguration(configList: List<InputConfig>) {
             Input.HINGE,
             Input.PAUSE,
             Input.FAST_FORWARD,
+            Input.FAST_FORWARD_HOLD,
             Input.MICROPHONE,
             Input.RESET,
             Input.SWAP_SCREENS,

--- a/app/src/main/java/me/magnum/melonds/domain/model/Input.kt
+++ b/app/src/main/java/me/magnum/melonds/domain/model/Input.kt
@@ -26,6 +26,7 @@ enum class Input(val keyCode: Int) {
     HINGE(16 + 7),
     PAUSE(-1),
     FAST_FORWARD(-1),
+    FAST_FORWARD_HOLD(-1),
     MICROPHONE(-1),
     RESET(-1),
     TOGGLE_SOFT_INPUT(-1),

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
@@ -192,6 +192,7 @@ class EmulatorActivity : AppCompatActivity() {
     private val frontendInputHandler = object : FrontendInputHandler() {
         var fastForwardEnabled = false
             private set
+        private var fastForwardHoldEnabled = false
         var microphoneEnabled = true
             private set
 
@@ -208,7 +209,17 @@ class EmulatorActivity : AppCompatActivity() {
             fastForwardEnabled = !fastForwardEnabled
             binding.viewLayoutControls.setLayoutComponentToggleState(LayoutComponent.BUTTON_FAST_FORWARD_TOGGLE, fastForwardEnabled)
             presentation?.layoutView?.setLayoutComponentToggleState(LayoutComponent.BUTTON_FAST_FORWARD_TOGGLE, fastForwardEnabled)
-            MelonEmulator.setFastForwardEnabled(fastForwardEnabled)
+            updateFastForwardState()
+        }
+
+        override fun onFastForwardHoldPressed() {
+            fastForwardHoldEnabled = true
+            updateFastForwardState()
+        }
+
+        override fun onFastForwardHoldReleased() {
+            fastForwardHoldEnabled = false
+            updateFastForwardState()
         }
 
         override fun onMicrophonePressed() {
@@ -236,6 +247,10 @@ class EmulatorActivity : AppCompatActivity() {
 
         override fun onRewind() {
             viewModel.onOpenRewind()
+        }
+
+        private fun updateFastForwardState() {
+            MelonEmulator.setFastForwardEnabled(fastForwardEnabled || fastForwardHoldEnabled)
         }
     }
     private val settingsLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/input/FrontendInputHandler.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/input/FrontendInputHandler.kt
@@ -8,6 +8,7 @@ abstract class FrontendInputHandler : IInputListener {
         when (key) {
             Input.PAUSE -> onPausePressed()
             Input.FAST_FORWARD -> onFastForwardPressed()
+            Input.FAST_FORWARD_HOLD -> onFastForwardHoldPressed()
             Input.MICROPHONE -> onMicrophonePressed()
             Input.TOGGLE_SOFT_INPUT -> onSoftInputTogglePressed()
             Input.RESET -> onResetPressed()
@@ -20,6 +21,10 @@ abstract class FrontendInputHandler : IInputListener {
     }
 
     override fun onKeyReleased(key: Input) {
+        when (key) {
+            Input.FAST_FORWARD_HOLD -> onFastForwardHoldReleased()
+            else -> {}
+        }
     }
 
     override fun onTouch(point: Point) {
@@ -27,6 +32,8 @@ abstract class FrontendInputHandler : IInputListener {
 
     abstract fun onPausePressed()
     abstract fun onFastForwardPressed()
+    abstract fun onFastForwardHoldPressed()
+    abstract fun onFastForwardHoldReleased()
     abstract fun onMicrophonePressed()
     abstract fun onSoftInputTogglePressed()
     abstract fun onResetPressed()

--- a/app/src/main/java/me/magnum/melonds/ui/inputsetup/ui/InputSetupScreen.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/inputsetup/ui/InputSetupScreen.kt
@@ -255,6 +255,7 @@ private fun getInputName(input: Input): String? {
         Input.HINGE -> R.string.input_lid
         Input.PAUSE -> R.string.input_pause
         Input.FAST_FORWARD -> R.string.input_fast_forward
+        Input.FAST_FORWARD_HOLD -> R.string.input_fast_forward_hold
         Input.MICROPHONE -> R.string.input_microphone
         Input.RESET -> R.string.input_reset
         Input.SWAP_SCREENS -> R.string.input_swap_screens

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -349,6 +349,7 @@
     <string name="input_lid">Toggle Lid</string>
     <string name="input_pause">Pause</string>
     <string name="input_fast_forward">Fast Forward (Toggle)</string>
+    <string name="input_fast_forward_hold">Fast Forward (Hold)</string>
     <string name="input_microphone">Toggle Microphone</string>
     <string name="input_toggle_soft_input">Toggle Soft Input</string>
     <string name="input_reset">@string/reset</string>


### PR DESCRIPTION
Adds a hold to fast-forward option alongside the existing toggle mode, based on this feature request/discussion: https://github.com/rafaelvcaetano/melonDS-android/discussions/1373. This allows for finer control during short moments and helps keep keybindings consistent across emulators, while keeping the current toggle behavior unchanged.