### PR TITLE
Move RetroAchievements config to ini file

### DIFF
--- a/app/src/main/java/me/magnum/melonds/common/retroachievements/AndroidRAUserAuthStore.kt
+++ b/app/src/main/java/me/magnum/melonds/common/retroachievements/AndroidRAUserAuthStore.kt
@@ -1,41 +1,26 @@
 package me.magnum.melonds.common.retroachievements
 
-import android.content.SharedPreferences
-import androidx.core.content.edit
 import me.magnum.rcheevosapi.RAUserAuthStore
 import me.magnum.rcheevosapi.model.RAUserAuth
 
-class AndroidRAUserAuthStore(private val sharedPreferences: SharedPreferences) : RAUserAuthStore {
-
-    private companion object {
-        const val USERNAME_KEY = "ra_username"
-        const val TOKEN_KEY = "ra_token"
-    }
+class AndroidRAUserAuthStore(private val retroAchievementsIniStore: RetroAchievementsIniStore) : RAUserAuthStore {
 
     override suspend fun storeUserAuth(userAuth: RAUserAuth.Authenticated) {
-        sharedPreferences.edit {
-            putString(USERNAME_KEY, userAuth.username)
-            putString(TOKEN_KEY, userAuth.token)
-        }
+        retroAchievementsIniStore.storeUserAuth(userAuth.username, userAuth.token)
     }
 
     override suspend fun getUserAuth(): RAUserAuth? {
-        val username = sharedPreferences.getString(USERNAME_KEY, null) ?: return null
-        val token = sharedPreferences.getString(TOKEN_KEY, null) ?: return RAUserAuth.AuthenticationExpired(username)
+        val username = retroAchievementsIniStore.getUsername() ?: return null
+        val token = retroAchievementsIniStore.getToken() ?: return RAUserAuth.AuthenticationExpired(username)
 
         return RAUserAuth.Authenticated(username, token)
     }
 
     override suspend fun clearUserAuth() {
-        sharedPreferences.edit {
-            remove(USERNAME_KEY)
-            remove(TOKEN_KEY)
-        }
+        retroAchievementsIniStore.clearUserAuth()
     }
 
     override suspend fun clearUserToken() {
-        sharedPreferences.edit {
-            remove(TOKEN_KEY)
-        }
+        retroAchievementsIniStore.clearUserToken()
     }
 }

--- a/app/src/main/java/me/magnum/melonds/common/retroachievements/RetroAchievementsIniStore.kt
+++ b/app/src/main/java/me/magnum/melonds/common/retroachievements/RetroAchievementsIniStore.kt
@@ -1,0 +1,249 @@
+package me.magnum.melonds.common.retroachievements
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import me.magnum.rcheevosapi.RAHostUrlProvider
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RetroAchievementsIniStore @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val sharedPreferences: SharedPreferences,
+) : RAHostUrlProvider {
+
+    private data class Config(
+        val hostUrl: String,
+        val username: String?,
+        val token: String?,
+        val hardcoreEnabled: Boolean,
+        val richPresenceEnabled: Boolean,
+        val activeChallengeIndicatorsEnabled: Boolean,
+        val progressIndicatorsEnabled: Boolean,
+        val leaderboardIndicatorsEnabled: Boolean,
+    )
+
+    private companion object {
+        const val FILE_NAME = "retroachievements.ini"
+        private const val SECTION_NAME = "[RetroAchievements]"
+
+        private const val HOST_URL_KEY = "HostUrl"
+        private const val USERNAME_KEY = "Username"
+        private const val TOKEN_KEY = "Token"
+        private const val HARDCORE_ENABLED_KEY = "HardcoreEnabled"
+        private const val RICH_PRESENCE_ENABLED_KEY = "RichPresence"
+        private const val ACTIVE_CHALLENGE_INDICATORS_ENABLED_KEY = "ActiveChallengeIndicators"
+        private const val PROGRESS_INDICATORS_ENABLED_KEY = "ProgressIndicators"
+        private const val LEADERBOARD_INDICATORS_ENABLED_KEY = "LeaderboardIndicators"
+
+        private const val LEGACY_USERNAME_KEY = "ra_username"
+        private const val LEGACY_TOKEN_KEY = "ra_token"
+        private const val LEGACY_HARDCORE_ENABLED_KEY = "ra_hardcore_enabled"
+        private const val LEGACY_RICH_PRESENCE_ENABLED_KEY = "ra_rich_presence"
+        private const val LEGACY_ACTIVE_CHALLENGE_INDICATORS_ENABLED_KEY = "ra_active_challenge_indicators"
+        private const val LEGACY_PROGRESS_INDICATORS_ENABLED_KEY = "ra_progress_indicators"
+        private const val LEGACY_LEADERBOARD_INDICATORS_ENABLED_KEY = "ra_leaderboard_indicators"
+    }
+
+    fun getIniFile(): File {
+        return File(context.getExternalFilesDir(null) ?: context.filesDir, FILE_NAME)
+    }
+
+    override fun getHostUrl(): String? {
+        return readConfig().hostUrl.ifBlank { null }
+    }
+
+    fun getUsername(): String? {
+        return readConfig().username
+    }
+
+    fun getToken(): String? {
+        return readConfig().token
+    }
+
+    fun storeUserAuth(username: String, token: String) {
+        updateConfig {
+            it.copy(
+                username = username.trim(),
+                token = token,
+            )
+        }
+    }
+
+    fun clearUserAuth() {
+        updateConfig {
+            it.copy(
+                username = null,
+                token = null,
+            )
+        }
+    }
+
+    fun clearUserToken() {
+        updateConfig {
+            it.copy(token = null)
+        }
+    }
+
+    fun isHardcoreEnabled(): Boolean {
+        return readConfig().hardcoreEnabled
+    }
+
+    fun setHardcoreEnabled(enabled: Boolean) {
+        updateConfig {
+            it.copy(hardcoreEnabled = enabled)
+        }
+    }
+
+    fun isRichPresenceEnabled(): Boolean {
+        return readConfig().richPresenceEnabled
+    }
+
+    fun setRichPresenceEnabled(enabled: Boolean) {
+        updateConfig {
+            it.copy(richPresenceEnabled = enabled)
+        }
+    }
+
+    fun areActiveChallengeIndicatorsEnabled(): Boolean {
+        return readConfig().activeChallengeIndicatorsEnabled
+    }
+
+    fun setActiveChallengeIndicatorsEnabled(enabled: Boolean) {
+        updateConfig {
+            it.copy(activeChallengeIndicatorsEnabled = enabled)
+        }
+    }
+
+    fun areProgressIndicatorsEnabled(): Boolean {
+        return readConfig().progressIndicatorsEnabled
+    }
+
+    fun setProgressIndicatorsEnabled(enabled: Boolean) {
+        updateConfig {
+            it.copy(progressIndicatorsEnabled = enabled)
+        }
+    }
+
+    fun areLeaderboardIndicatorsEnabled(): Boolean {
+        return readConfig().leaderboardIndicatorsEnabled
+    }
+
+    fun setLeaderboardIndicatorsEnabled(enabled: Boolean) {
+        updateConfig {
+            it.copy(leaderboardIndicatorsEnabled = enabled)
+        }
+    }
+
+    @Synchronized
+    private fun readConfig(): Config {
+        ensureFileExists()
+        return parseConfig(getIniFile())
+    }
+
+    @Synchronized
+    private fun updateConfig(transform: (Config) -> Config) {
+        val updatedConfig = transform(readConfig())
+        writeConfig(getIniFile(), updatedConfig)
+    }
+
+    private fun ensureFileExists() {
+        val iniFile = getIniFile()
+        if (iniFile.exists()) {
+            return
+        }
+
+        writeConfig(iniFile, buildInitialConfig())
+    }
+
+    private fun buildInitialConfig(): Config {
+        return Config(
+            hostUrl = "",
+            username = sharedPreferences.getString(LEGACY_USERNAME_KEY, null)?.trim()?.ifEmpty { null },
+            token = sharedPreferences.getString(LEGACY_TOKEN_KEY, null),
+            hardcoreEnabled = sharedPreferences.getBoolean(LEGACY_HARDCORE_ENABLED_KEY, false),
+            richPresenceEnabled = sharedPreferences.getBoolean(LEGACY_RICH_PRESENCE_ENABLED_KEY, true),
+            activeChallengeIndicatorsEnabled = sharedPreferences.getBoolean(LEGACY_ACTIVE_CHALLENGE_INDICATORS_ENABLED_KEY, true),
+            progressIndicatorsEnabled = sharedPreferences.getBoolean(LEGACY_PROGRESS_INDICATORS_ENABLED_KEY, true),
+            leaderboardIndicatorsEnabled = sharedPreferences.getBoolean(LEGACY_LEADERBOARD_INDICATORS_ENABLED_KEY, true),
+        )
+    }
+
+    private fun parseConfig(file: File): Config {
+        var hostUrl = ""
+        var username: String? = null
+        var token: String? = null
+        var hardcoreEnabled = false
+        var richPresenceEnabled = true
+        var activeChallengeIndicatorsEnabled = true
+        var progressIndicatorsEnabled = true
+        var leaderboardIndicatorsEnabled = true
+        var inRetroAchievementsSection = false
+
+        file.forEachLine { rawLine ->
+            val line = rawLine.trim()
+            if (line.isEmpty() || line.startsWith(";") || line.startsWith("#")) {
+                return@forEachLine
+            }
+
+            if (line.startsWith("[") && line.endsWith("]")) {
+                inRetroAchievementsSection = line == SECTION_NAME
+                return@forEachLine
+            }
+
+            if (!inRetroAchievementsSection) {
+                return@forEachLine
+            }
+
+            val separatorIndex = line.indexOf('=')
+            if (separatorIndex < 0) {
+                return@forEachLine
+            }
+
+            val key = line.substring(0, separatorIndex).trim()
+            val value = line.substring(separatorIndex + 1)
+
+            when (key) {
+                HOST_URL_KEY -> hostUrl = value.trim()
+                USERNAME_KEY -> username = value.trim().ifEmpty { null }
+                TOKEN_KEY -> token = value.ifEmpty { null }
+                HARDCORE_ENABLED_KEY -> hardcoreEnabled = value.toBooleanStrictOrNull() ?: false
+                RICH_PRESENCE_ENABLED_KEY -> richPresenceEnabled = value.toBooleanStrictOrNull() ?: true
+                ACTIVE_CHALLENGE_INDICATORS_ENABLED_KEY -> activeChallengeIndicatorsEnabled = value.toBooleanStrictOrNull() ?: true
+                PROGRESS_INDICATORS_ENABLED_KEY -> progressIndicatorsEnabled = value.toBooleanStrictOrNull() ?: true
+                LEADERBOARD_INDICATORS_ENABLED_KEY -> leaderboardIndicatorsEnabled = value.toBooleanStrictOrNull() ?: true
+            }
+        }
+
+        return Config(
+            hostUrl = hostUrl,
+            username = username,
+            token = token,
+            hardcoreEnabled = hardcoreEnabled,
+            richPresenceEnabled = richPresenceEnabled,
+            activeChallengeIndicatorsEnabled = activeChallengeIndicatorsEnabled,
+            progressIndicatorsEnabled = progressIndicatorsEnabled,
+            leaderboardIndicatorsEnabled = leaderboardIndicatorsEnabled,
+        )
+    }
+
+    private fun writeConfig(file: File, config: Config) {
+        file.parentFile?.mkdirs()
+
+        file.writeText(
+            buildString {
+                appendLine(SECTION_NAME)
+                appendLine("$HOST_URL_KEY=${config.hostUrl}")
+                appendLine("$USERNAME_KEY=${config.username.orEmpty()}")
+                appendLine("$TOKEN_KEY=${config.token.orEmpty()}")
+                appendLine("$HARDCORE_ENABLED_KEY=${config.hardcoreEnabled}")
+                appendLine("$RICH_PRESENCE_ENABLED_KEY=${config.richPresenceEnabled}")
+                appendLine("$ACTIVE_CHALLENGE_INDICATORS_ENABLED_KEY=${config.activeChallengeIndicatorsEnabled}")
+                appendLine("$PROGRESS_INDICATORS_ENABLED_KEY=${config.progressIndicatorsEnabled}")
+                appendLine("$LEADERBOARD_INDICATORS_ENABLED_KEY=${config.leaderboardIndicatorsEnabled}")
+            }
+        )
+    }
+}

--- a/app/src/main/java/me/magnum/melonds/common/retroachievements/RetroAchievementsPreferenceDataStore.kt
+++ b/app/src/main/java/me/magnum/melonds/common/retroachievements/RetroAchievementsPreferenceDataStore.kt
@@ -1,0 +1,29 @@
+package me.magnum.melonds.common.retroachievements
+
+import androidx.preference.PreferenceDataStore
+
+class RetroAchievementsPreferenceDataStore(
+    private val retroAchievementsIniStore: RetroAchievementsIniStore,
+) : PreferenceDataStore() {
+
+    override fun putBoolean(key: String?, value: Boolean) {
+        when (key) {
+            "ra_hardcore_enabled" -> retroAchievementsIniStore.setHardcoreEnabled(value)
+            "ra_rich_presence" -> retroAchievementsIniStore.setRichPresenceEnabled(value)
+            "ra_active_challenge_indicators" -> retroAchievementsIniStore.setActiveChallengeIndicatorsEnabled(value)
+            "ra_progress_indicators" -> retroAchievementsIniStore.setProgressIndicatorsEnabled(value)
+            "ra_leaderboard_indicators" -> retroAchievementsIniStore.setLeaderboardIndicatorsEnabled(value)
+        }
+    }
+
+    override fun getBoolean(key: String?, defValue: Boolean): Boolean {
+        return when (key) {
+            "ra_hardcore_enabled" -> retroAchievementsIniStore.isHardcoreEnabled()
+            "ra_rich_presence" -> retroAchievementsIniStore.isRichPresenceEnabled()
+            "ra_active_challenge_indicators" -> retroAchievementsIniStore.areActiveChallengeIndicatorsEnabled()
+            "ra_progress_indicators" -> retroAchievementsIniStore.areProgressIndicatorsEnabled()
+            "ra_leaderboard_indicators" -> retroAchievementsIniStore.areLeaderboardIndicatorsEnabled()
+            else -> defValue
+        }
+    }
+}

--- a/app/src/main/java/me/magnum/melonds/di/MelonModule.kt
+++ b/app/src/main/java/me/magnum/melonds/di/MelonModule.kt
@@ -15,6 +15,7 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.json.Json
+import me.magnum.melonds.common.retroachievements.RetroAchievementsIniStore
 import me.magnum.melonds.common.romprocessors.RomFileProcessorFactory
 import me.magnum.melonds.common.uridelegates.UriHandler
 import me.magnum.melonds.common.vibration.Api26VibratorDelegate
@@ -52,8 +53,8 @@ object MelonModule {
 
     @Provides
     @Singleton
-    fun provideSettingsRepository(@ApplicationContext context: Context, sharedPreferences: SharedPreferences, controllerConfigurationFactory: ControllerConfigurationFactory, json: Json, uriHandler: UriHandler): SettingsRepository {
-        return SharedPreferencesSettingsRepository(context, sharedPreferences, controllerConfigurationFactory, json, uriHandler, CoroutineScope(Dispatchers.IO))
+    fun provideSettingsRepository(@ApplicationContext context: Context, sharedPreferences: SharedPreferences, retroAchievementsIniStore: RetroAchievementsIniStore, controllerConfigurationFactory: ControllerConfigurationFactory, json: Json, uriHandler: UriHandler): SettingsRepository {
+        return SharedPreferencesSettingsRepository(context, sharedPreferences, retroAchievementsIniStore, controllerConfigurationFactory, json, uriHandler, CoroutineScope(Dispatchers.IO))
     }
 
     @Provides

--- a/app/src/main/java/me/magnum/melonds/di/RAModule.kt
+++ b/app/src/main/java/me/magnum/melonds/di/RAModule.kt
@@ -9,8 +9,10 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import me.magnum.melonds.common.network.MelonOkHttpInterceptor
+import me.magnum.melonds.common.retroachievements.RetroAchievementsIniStore
 import me.magnum.melonds.common.retroachievements.AndroidRASignatureProvider
 import me.magnum.melonds.common.retroachievements.AndroidRAUserAuthStore
+import me.magnum.rcheevosapi.RAHostUrlProvider
 import me.magnum.rcheevosapi.RASignatureProvider
 import me.magnum.rcheevosapi.RAApi
 import me.magnum.rcheevosapi.RAUserAuthStore
@@ -37,8 +39,14 @@ object RAModule {
 
     @Provides
     @Singleton
-    fun provideRAUserAuthStore(sharedPreferences: SharedPreferences): RAUserAuthStore {
-        return AndroidRAUserAuthStore(sharedPreferences)
+    fun provideRAUserAuthStore(retroAchievementsIniStore: RetroAchievementsIniStore): RAUserAuthStore {
+        return AndroidRAUserAuthStore(retroAchievementsIniStore)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRAHostUrlProvider(retroAchievementsIniStore: RetroAchievementsIniStore): RAHostUrlProvider {
+        return retroAchievementsIniStore
     }
 
     @Provides
@@ -49,11 +57,12 @@ object RAModule {
 
     @Provides
     @Singleton
-    fun provideRAApi(@Named("ra-api-client") client: OkHttpClient, json: Json, userAuthStore: RAUserAuthStore, achievementSignatureProvider: RASignatureProvider): RAApi {
+    fun provideRAApi(@Named("ra-api-client") client: OkHttpClient, json: Json, userAuthStore: RAUserAuthStore, hostUrlProvider: RAHostUrlProvider, achievementSignatureProvider: RASignatureProvider): RAApi {
         return RAApi(
             okHttpClient = client,
             json = json,
             userAuthStore = userAuthStore,
+            hostUrlProvider = hostUrlProvider,
             signatureProvider = achievementSignatureProvider,
         )
     }

--- a/app/src/main/java/me/magnum/melonds/impl/SharedPreferencesSettingsRepository.kt
+++ b/app/src/main/java/me/magnum/melonds/impl/SharedPreferencesSettingsRepository.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
+import me.magnum.melonds.common.retroachievements.RetroAchievementsIniStore
 import me.magnum.melonds.common.uridelegates.UriHandler
 import me.magnum.melonds.domain.model.AudioBitrate
 import me.magnum.melonds.domain.model.AudioInterpolation
@@ -61,6 +62,7 @@ import kotlin.math.pow
 class SharedPreferencesSettingsRepository(
     private val context: Context,
     private val preferences: SharedPreferences,
+    private val retroAchievementsIniStore: RetroAchievementsIniStore,
     private val controllerConfigurationFactory: ControllerConfigurationFactory,
     private val json: Json,
     private val uriHandler: UriHandler,
@@ -469,23 +471,23 @@ class SharedPreferencesSettingsRepository(
     }
 
     override fun isRetroAchievementsRichPresenceEnabled(): Boolean {
-        return preferences.getBoolean("ra_rich_presence", true)
+        return retroAchievementsIniStore.isRichPresenceEnabled()
     }
 
     override fun isRetroAchievementsHardcoreEnabled(): Boolean {
-        return preferences.getBoolean("ra_hardcore_enabled", false)
+        return retroAchievementsIniStore.isHardcoreEnabled()
     }
 
     override fun areRetroAchievementsActiveChallengeIndicatorsEnabled(): Boolean {
-        return preferences.getBoolean("ra_active_challenge_indicators", true)
+        return retroAchievementsIniStore.areActiveChallengeIndicatorsEnabled()
     }
 
     override fun areRetroAchievementsProgressIndicatorsEnabled(): Boolean {
-        return preferences.getBoolean("ra_progress_indicators", true)
+        return retroAchievementsIniStore.areProgressIndicatorsEnabled()
     }
 
     override fun areRetroAchievementsLeaderboardIndicatorsEnabled(): Boolean {
-        return preferences.getBoolean("ra_leaderboard_indicators", true)
+        return retroAchievementsIniStore.areLeaderboardIndicatorsEnabled()
     }
 
     override fun areCheatsEnabled(): Boolean {

--- a/app/src/main/java/me/magnum/melonds/ui/settings/fragments/RetroAchievementsPreferencesFragment.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/settings/fragments/RetroAchievementsPreferencesFragment.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import me.magnum.melonds.R
+import me.magnum.melonds.common.retroachievements.RetroAchievementsIniStore
+import me.magnum.melonds.common.retroachievements.RetroAchievementsPreferenceDataStore
 import me.magnum.melonds.databinding.DialogRetroachievementsLoginBinding
 import me.magnum.melonds.extensions.addOnPreferenceChangeListener
 import me.magnum.melonds.ui.common.LoadingDialog
@@ -23,15 +25,20 @@ import me.magnum.melonds.ui.settings.PreferenceFragmentTitleProvider
 import me.magnum.melonds.ui.settings.flow.observeAsFlow
 import me.magnum.melonds.ui.settings.model.RetroAchievementsAccountState
 import me.magnum.melonds.ui.settings.viewmodel.RetroAchievementsSettingsViewModel
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class RetroAchievementsPreferencesFragment : BasePreferenceFragment(), PreferenceFragmentTitleProvider {
+
+    @Inject
+    lateinit var retroAchievementsIniStore: RetroAchievementsIniStore
 
     private val viewModel by viewModels<RetroAchievementsSettingsViewModel>()
 
     private var loginProgressDialog: LoadingDialog? = null
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        preferenceManager.preferenceDataStore = RetroAchievementsPreferenceDataStore(retroAchievementsIniStore)
         setPreferencesFromResource(R.xml.pref_retroachievements, rootKey)
 
         val accountPreference = findPreference<Preference>("ra_login")!!

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
+        <domain>127.0.0.1</domain>
+        <domain>localhost</domain>
+    </domain-config>
+
+    <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">nus.cdn.t.shop.nintendowifi.net</domain>
     </domain-config>
 

--- a/rcheevos-api/src/main/java/me/magnum/rcheevosapi/RAApi.kt
+++ b/rcheevos-api/src/main/java/me/magnum/rcheevosapi/RAApi.kt
@@ -44,11 +44,12 @@ class RAApi(
     private val okHttpClient: OkHttpClient,
     private val json: Json,
     private val userAuthStore: RAUserAuthStore,
+    private val hostUrlProvider: RAHostUrlProvider,
     private val signatureProvider: RASignatureProvider,
 ) {
 
     companion object {
-        private const val BASE_URL = "https://retroachievements.org/dorequest.php"
+        private const val DEFAULT_BASE_URL = "https://retroachievements.org/dorequest.php"
 
         private const val PARAMETER_USER = "u"
         private const val PARAMETER_PASSWORD = "p"
@@ -317,7 +318,7 @@ class RAApi(
             "${URLEncoder.encode(it.key, "utf-8")}=${URLEncoder.encode(it.value, "utf-8")}"
         }.joinToString(separator = "&")
 
-        val url = "$BASE_URL?$query"
+        val url = "${getBaseUrl()}?$query"
 
         return Request.Builder()
             .get()
@@ -332,8 +333,31 @@ class RAApi(
 
         return Request.Builder()
             .post(data.toRequestBody("application/x-www-form-urlencoded".toMediaType()))
-            .url(BASE_URL)
+            .url(getBaseUrl())
             .build()
+    }
+
+    private fun getBaseUrl(): String {
+        val hostUrl = hostUrlProvider.getHostUrl()?.trim().orEmpty()
+        if (hostUrl.isEmpty()) {
+            return DEFAULT_BASE_URL
+        }
+
+        val normalizedHost = hostUrl
+            .let {
+                if (it.startsWith("http://", ignoreCase = true) || it.startsWith("https://", ignoreCase = true)) {
+                    it
+                } else {
+                    "http://$it"
+                }
+            }
+            .removeSuffix("/")
+
+        return if (normalizedHost.endsWith("/dorequest.php")) {
+            normalizedHost
+        } else {
+            "$normalizedHost/dorequest.php"
+        }
     }
 
     private suspend fun executeRequest(request: Request): Response = suspendCancellableCoroutine { continuation ->

--- a/rcheevos-api/src/main/java/me/magnum/rcheevosapi/RAHostUrlProvider.kt
+++ b/rcheevos-api/src/main/java/me/magnum/rcheevosapi/RAHostUrlProvider.kt
@@ -1,0 +1,5 @@
+package me.magnum.rcheevosapi
+
+interface RAHostUrlProvider {
+    fun getHostUrl(): String?
+}


### PR DESCRIPTION
## Summary
- move RetroAchievements auth and toggle settings into `Android/data/<package>/files/retroachievements.ini`, with one-time migration from the existing internal preferences
- add optional `HostUrl` support so melonDS can route RetroAchievements API calls through a locally running proxy while keeping the host hidden from the UI
- allow loopback cleartext requests and normalize `HostUrl` values like `127.0.0.1:PORT` to `http://127.0.0.1:PORT`

## Why
[RAOfflineProxy](https://raofflineproxy.com/) is an Android app that runs a local HTTP proxy between emulators and the RetroAchievements API. It caches RetroAchievements responses for offline use, supports replaying softcore achievement awards once connectivity returns, and lets RetroAchievements traffic be redirected through `127.0.0.1` on the device.

To integrate with that workflow, melonDS needs two things that are difficult with the current implementation:
- RetroAchievements settings stored in a file that can be inspected and adjusted outside the app
- a way to override the RetroAchievements host without exposing a new UI setting

This change keeps the default behavior intact when `HostUrl` is empty, but makes it possible to point melonDS at a local proxy by editing `retroachievements.ini` externally.

## Notes
- the app creates `retroachievements.ini` on first RetroAchievements access if it does not exist yet
- the generated file includes an empty `HostUrl=` entry and migrates the existing RetroAchievements username/token and toggle values
- if `HostUrl` is empty, requests still go to `https://retroachievements.org/dorequest.php`