### PR TITLE
Android: add RetroAchievements host override receiver

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -147,6 +147,15 @@
             android:label="@string/backgrounds">
         </activity>
 
+        <receiver
+            android:name=".common.retroachievements.RetroAchievementsHostOverrideReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="${applicationId}.action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+                <action android:name="${applicationId}.action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+            </intent-filter>
+        </receiver>
+
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"

--- a/app/src/main/java/me/magnum/melonds/common/AppPreferences.kt
+++ b/app/src/main/java/me/magnum/melonds/common/AppPreferences.kt
@@ -1,0 +1,8 @@
+package me.magnum.melonds.common
+
+import android.content.Context
+import android.content.SharedPreferences
+
+fun appSharedPreferences(context: Context): SharedPreferences {
+    return context.getSharedPreferences("${context.packageName}_preferences", Context.MODE_PRIVATE)
+}

--- a/app/src/main/java/me/magnum/melonds/common/retroachievements/RetroAchievementsHostOverrideReceiver.kt
+++ b/app/src/main/java/me/magnum/melonds/common/retroachievements/RetroAchievementsHostOverrideReceiver.kt
@@ -1,0 +1,35 @@
+package me.magnum.melonds.common.retroachievements
+
+import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import me.magnum.melonds.common.appSharedPreferences
+
+class RetroAchievementsHostOverrideReceiver : BroadcastReceiver() {
+
+    companion object {
+        private const val ACTION_SET_HOST_OVERRIDE_SUFFIX = ".action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE"
+        private const val ACTION_CLEAR_HOST_OVERRIDE_SUFFIX = ".action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE"
+        const val EXTRA_HOST = "host"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val sharedPreferences = appSharedPreferences(context)
+        val hostUrlProvider = SharedPreferencesRAHostUrlProvider(sharedPreferences)
+        val packageName = context.packageName
+        val setAction = packageName + ACTION_SET_HOST_OVERRIDE_SUFFIX
+        val clearAction = packageName + ACTION_CLEAR_HOST_OVERRIDE_SUFFIX
+
+        when (intent.action) {
+            setAction -> {
+                val host = intent.getStringExtra(EXTRA_HOST)
+                if (!hostUrlProvider.setBaseUrl(host.orEmpty())) {
+                    resultCode = Activity.RESULT_CANCELED
+                }
+            }
+
+            clearAction -> hostUrlProvider.clearBaseUrl()
+        }
+    }
+}

--- a/app/src/main/java/me/magnum/melonds/common/retroachievements/SharedPreferencesRAHostUrlProvider.kt
+++ b/app/src/main/java/me/magnum/melonds/common/retroachievements/SharedPreferencesRAHostUrlProvider.kt
@@ -1,0 +1,95 @@
+package me.magnum.melonds.common.retroachievements
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import me.magnum.rcheevosapi.RAHostUrlProvider
+import java.net.URI
+import java.util.Locale
+
+class SharedPreferencesRAHostUrlProvider(
+    private val sharedPreferences: SharedPreferences,
+) : RAHostUrlProvider {
+
+    companion object {
+        const val HOST_URL_KEY = "ra_host_url"
+        const val DEFAULT_BASE_URL = "https://retroachievements.org/dorequest.php"
+        private const val HARDCORE_ENABLED_KEY = "ra_hardcore_enabled"
+        private const val HARDCORE_RESTORE_KEY = "ra_hardcore_enabled_restore"
+    }
+
+    override fun getBaseUrl(): String {
+        val configuredUrl = sharedPreferences.getString(HOST_URL_KEY, null)
+        val normalizedUrl = normalize(configuredUrl)
+
+        return normalizedUrl ?: DEFAULT_BASE_URL
+    }
+
+    fun setBaseUrl(host: String): Boolean {
+        val normalizedHost = normalize(host) ?: return false
+        val hasExistingOverride = !sharedPreferences.getString(HOST_URL_KEY, null).isNullOrBlank()
+        val currentHardcoreEnabled = sharedPreferences.getBoolean(HARDCORE_ENABLED_KEY, false)
+
+        sharedPreferences.edit(commit = true) {
+            putString(HOST_URL_KEY, normalizedHost)
+            if (!hasExistingOverride) {
+                putBoolean(HARDCORE_RESTORE_KEY, currentHardcoreEnabled)
+            }
+            putBoolean(HARDCORE_ENABLED_KEY, false)
+        }
+
+        return true
+    }
+
+    fun clearBaseUrl() {
+        val hasRestoreValue = sharedPreferences.contains(HARDCORE_RESTORE_KEY)
+        val restoreHardcore = sharedPreferences.getBoolean(HARDCORE_RESTORE_KEY, false)
+
+        sharedPreferences.edit(commit = true) {
+            remove(HOST_URL_KEY)
+            if (hasRestoreValue) {
+                putBoolean(HARDCORE_ENABLED_KEY, restoreHardcore)
+            }
+            remove(HARDCORE_RESTORE_KEY)
+        }
+    }
+
+    private fun normalize(value: String?): String? {
+        val trimmedValue = value?.trim().orEmpty()
+
+        if (trimmedValue.isEmpty()) {
+            return null
+        }
+
+        val candidate = if ("://" in trimmedValue) {
+            trimmedValue
+        } else {
+            "http://$trimmedValue"
+        }
+
+        val uri = runCatching { URI(candidate) }.getOrNull() ?: return null
+        val scheme = uri.scheme?.lowercase(Locale.US) ?: return null
+        val host = uri.host?.lowercase(Locale.US) ?: return null
+
+        if (scheme != "http") {
+            return null
+        }
+
+        if (host != "127.0.0.1" && host != "localhost") {
+            return null
+        }
+
+        if (uri.port !in 1..65535) {
+            return null
+        }
+
+        if (!uri.rawPath.isNullOrEmpty() && uri.rawPath != "/" && uri.rawPath != "/dorequest.php") {
+            return null
+        }
+
+        if (uri.rawQuery != null || uri.rawFragment != null || uri.userInfo != null) {
+            return null
+        }
+
+        return URI(scheme, null, host, uri.port, "/dorequest.php", null, null).toASCIIString()
+    }
+}

--- a/app/src/main/java/me/magnum/melonds/di/AppModule.kt
+++ b/app/src/main/java/me/magnum/melonds/di/AppModule.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.net.Uri
 import android.text.util.Linkify
-import androidx.preference.PreferenceManager
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.squareup.picasso.Picasso
@@ -21,6 +20,7 @@ import kotlinx.serialization.json.Json
 import me.magnum.melonds.common.DirectoryAccessValidator
 import me.magnum.melonds.common.PermissionHandler
 import me.magnum.melonds.common.UriPermissionManager
+import me.magnum.melonds.common.appSharedPreferences
 import me.magnum.melonds.common.uridelegates.CompositeUriHandler
 import me.magnum.melonds.common.uridelegates.UriHandler
 import me.magnum.melonds.impl.system.AppForegroundStateObserver
@@ -37,7 +37,7 @@ object AppModule {
     @Provides
     @Singleton
     fun provideSharedPreferences(@ApplicationContext context: Context): SharedPreferences {
-        return PreferenceManager.getDefaultSharedPreferences(context)
+        return appSharedPreferences(context)
     }
 
     @Provides

--- a/app/src/main/java/me/magnum/melonds/di/RAModule.kt
+++ b/app/src/main/java/me/magnum/melonds/di/RAModule.kt
@@ -10,9 +10,11 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import me.magnum.melonds.common.network.MelonOkHttpInterceptor
 import me.magnum.melonds.common.retroachievements.AndroidRASignatureProvider
+import me.magnum.melonds.common.retroachievements.SharedPreferencesRAHostUrlProvider
 import me.magnum.melonds.common.retroachievements.AndroidRAUserAuthStore
 import me.magnum.rcheevosapi.RASignatureProvider
 import me.magnum.rcheevosapi.RAApi
+import me.magnum.rcheevosapi.RAHostUrlProvider
 import me.magnum.rcheevosapi.RAUserAuthStore
 import okhttp3.OkHttpClient
 import javax.inject.Named
@@ -49,10 +51,17 @@ object RAModule {
 
     @Provides
     @Singleton
-    fun provideRAApi(@Named("ra-api-client") client: OkHttpClient, json: Json, userAuthStore: RAUserAuthStore, achievementSignatureProvider: RASignatureProvider): RAApi {
+    fun provideRAHostUrlProvider(sharedPreferences: SharedPreferences): RAHostUrlProvider {
+        return SharedPreferencesRAHostUrlProvider(sharedPreferences)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRAApi(@Named("ra-api-client") client: OkHttpClient, json: Json, hostUrlProvider: RAHostUrlProvider, userAuthStore: RAUserAuthStore, achievementSignatureProvider: RASignatureProvider): RAApi {
         return RAApi(
             okHttpClient = client,
             json = json,
+            hostUrlProvider = hostUrlProvider,
             userAuthStore = userAuthStore,
             signatureProvider = achievementSignatureProvider,
         )

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -4,6 +4,11 @@
         <domain includeSubdomains="true">nus.cdn.t.shop.nintendowifi.net</domain>
     </domain-config>
 
+    <domain-config cleartextTrafficPermitted="true">
+        <domain>127.0.0.1</domain>
+        <domain>localhost</domain>
+    </domain-config>
+
     <debug-overrides>
         <trust-anchors>
             <certificates src="user" />

--- a/rcheevos-api/src/main/java/me/magnum/rcheevosapi/RAApi.kt
+++ b/rcheevos-api/src/main/java/me/magnum/rcheevosapi/RAApi.kt
@@ -43,13 +43,12 @@ import kotlin.reflect.KClass
 class RAApi(
     private val okHttpClient: OkHttpClient,
     private val json: Json,
+    private val hostUrlProvider: RAHostUrlProvider,
     private val userAuthStore: RAUserAuthStore,
     private val signatureProvider: RASignatureProvider,
 ) {
 
     companion object {
-        private const val BASE_URL = "https://retroachievements.org/dorequest.php"
-
         private const val PARAMETER_USER = "u"
         private const val PARAMETER_PASSWORD = "p"
         private const val PARAMETER_TOKEN = "t"
@@ -317,7 +316,7 @@ class RAApi(
             "${URLEncoder.encode(it.key, "utf-8")}=${URLEncoder.encode(it.value, "utf-8")}"
         }.joinToString(separator = "&")
 
-        val url = "$BASE_URL?$query"
+        val url = "${hostUrlProvider.getBaseUrl()}?$query"
 
         return Request.Builder()
             .get()
@@ -332,7 +331,7 @@ class RAApi(
 
         return Request.Builder()
             .post(data.toRequestBody("application/x-www-form-urlencoded".toMediaType()))
-            .url(BASE_URL)
+            .url(hostUrlProvider.getBaseUrl())
             .build()
     }
 

--- a/rcheevos-api/src/main/java/me/magnum/rcheevosapi/RAHostUrlProvider.kt
+++ b/rcheevos-api/src/main/java/me/magnum/rcheevosapi/RAHostUrlProvider.kt
@@ -1,0 +1,5 @@
+package me.magnum.rcheevosapi
+
+interface RAHostUrlProvider {
+    fun getBaseUrl(): String
+}


### PR DESCRIPTION
## Summary

This PR adds a broadcast-based RetroAchievements host override for melonDS.

It is a follow-up to #1627. After working on that earlier approach, I found a much smaller and more self-contained way to support the same integration goal without moving RetroAchievements settings into an external ini file.

This is the same general technique used in PPSSPP here:
https://github.com/hrydgard/ppsspp/pull/21760

That PR was approved and merged by @hrydgard, and it ended up being a good fit where an external companion app needs a temporary runtime override without introducing a user-facing setting.

## What this does

This PR adds two broadcast actions:

- `${applicationId}.action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE`
- `${applicationId}.action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE`

The `SET` action accepts a `host` extra and stores a normalized loopback-only RetroAchievements endpoint override in app preferences.

Examples accepted by the receiver:

- `127.0.0.1:8080`
- `localhost:8080`
- `http://127.0.0.1:8080`
- `http://localhost:8080`

These are normalized internally to:

- `http://127.0.0.1:PORT/dorequest.php`
- `http://localhost:PORT/dorequest.php`

Only loopback `http` targets are accepted.

## Technical details

The implementation is intentionally small and self-contained:

- add a manifest-declared `BroadcastReceiver` for set/clear override actions
- persist the override in app preferences
- make `RAApi` resolve its base URL from a provider instead of a hardcoded constant
- allow loopback cleartext traffic in `network_security_config.xml`
- force RetroAchievements softcore mode while the override is active
- restore the user’s previous hardcore preference when the override is cleared

Importantly, this does not add a new UI setting and does not change normal behavior when no override is set.

## Why this is preferable to #1627

Compared with #1627, this approach avoids:

- moving RetroAchievements auth and settings into an external ini file
- migration logic from the existing preferences
- broader settings storage changes
- exposing more external surface area than necessary

If the only requirement is "allow a companion app to redirect RetroAchievements traffic to a local loopback proxy", a broadcast receiver is a much narrower solution.

## Why this should not interfere with melonDS features

This is intended as an optional integration hook, not a replacement for melonDS’s own RetroAchievements behavior.

When no override is set:

- RetroAchievements still uses the normal upstream host
- existing settings continue to work as before
- there is no new visible configuration for regular users

When an override is set:

- requests are redirected only for that explicit integration case
- hardcore is forced off only while the override is active
- the previous hardcore preference is restored on clear

So this should stay isolated from other emulator functionality, including any future or existing melonDS-side RetroAchievements/offline work.

## Motivation

My use case is integration with RAOfflineProxy, which runs a local loopback proxy/cache for RetroAchievements traffic.

The goal is to provide one centralized proxy/cache layer that multiple emulators can optionally target, instead of re-implementing similar integration logic separately in each emulator.

This PR only adds the minimal hook needed for that workflow.

## Notes

- only loopback `http` hosts are accepted
- no behavior changes occur unless a companion app explicitly sends the broadcast
