### PR TITLE
Fix ROM not found error when launching from external apps

### DIFF
--- a/app/src/main/java/me/magnum/melonds/common/UriPermissionManager.kt
+++ b/app/src/main/java/me/magnum/melonds/common/UriPermissionManager.kt
@@ -14,4 +14,14 @@ class UriPermissionManager(private val context: Context) {
         val flags = permission.toFlags()
         context.contentResolver.takePersistableUriPermission(fileUri, flags)
     }
+
+    // Same as [persistFilePermissions] but does not throw if [fileUri] was not granted a persistable permission
+    fun tryPersistFilePermissions(fileUri: Uri, permission: Permission): Boolean {
+        return try {
+            context.contentResolver.takePersistableUriPermission(fileUri, permission.toFlags())
+            true
+        } catch (e: SecurityException) {
+            false
+        }
+    }
 }

--- a/app/src/main/java/me/magnum/melonds/impl/FileSystemRomsRepository.kt
+++ b/app/src/main/java/me/magnum/melonds/impl/FileSystemRomsRepository.kt
@@ -107,22 +107,35 @@ class FileSystemRomsRepository(
         allRoms.find { rom -> rom.uri == uri }?.let { return it }
 
         // Pre-filter by filename for performance
-        val incomingFileName = DocumentFile.fromSingleUri(context, uri)?.name
+        val incomingFileName = runCatching { DocumentFile.fromSingleUri(context, uri)?.name }.getOrNull()
         val candidateRoms = if (incomingFileName != null) {
             allRoms.filter { it.fileName == incomingFileName }
         } else {
             allRoms
         }
 
-        // Try to find matching ROM by path, then by size (filename already pre-filtered)
-        val cachedRom = findRomByPath(candidateRoms, uri)
+        // Try to find matching ROM by document id, then by path, then by size (filename already pre-filtered)
+        val cachedRom = findRomByDocumentId(candidateRoms, uri)
+            ?: findRomByPath(candidateRoms, uri)
             ?: findRomBySize(candidateRoms, uri)
 
         if (cachedRom != null)
             return cachedRom
 
         // ROM is not known. Create a new ROM from the URI
+        Log.i(TAG, "getRomAtUri: no cached ROM matched for $uri, falling back to ad-hoc import")
         return romFileProcessorFactory.getFileRomProcessorForDocument(uri)?.getRomFromUri(uri, null)
+    }
+
+    // Matches [uri] against a cached ROM's URI by comparing their SAF document IDs directly
+    private fun findRomByDocumentId(roms: List<Rom>, uri: Uri): Rom? {
+        if (uri.authority != EXTERNAL_STORAGE_PROVIDER_AUTHORITY) return null
+        val incomingDocId = FileUtils.getDocumentIdOrNull(context, uri) ?: return null
+
+        return roms.find { rom ->
+            rom.uri.authority == EXTERNAL_STORAGE_PROVIDER_AUTHORITY &&
+                FileUtils.getDocumentIdOrNull(context, rom.uri)?.equals(incomingDocId, ignoreCase = true) == true
+        }
     }
 
     private fun findRomByPath(roms: List<Rom>, uri: Uri): Rom? {

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
@@ -51,7 +51,9 @@ import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
 import me.magnum.melonds.MelonEmulator
 import me.magnum.melonds.R
+import me.magnum.melonds.common.Permission
 import me.magnum.melonds.common.PermissionHandler
+import me.magnum.melonds.common.UriPermissionManager
 import me.magnum.melonds.databinding.ActivityEmulatorBinding
 import me.magnum.melonds.domain.model.ConsoleType
 import me.magnum.melonds.domain.model.ControllerConfiguration
@@ -160,6 +162,9 @@ class EmulatorActivity : AppCompatActivity() {
 
     @Inject
     lateinit var appForegroundStateObserver: AppForegroundStateObserver
+
+    @Inject
+    lateinit var uriPermissionManager: UriPermissionManager
 
     private var presentation: ExternalPresentation? = null
 
@@ -283,6 +288,7 @@ class EmulatorActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        intent.data?.let { uriPermissionManager.tryPersistFilePermissions(it, Permission.READ) }
         handler = Handler(mainLooper)
         lifecycleOwnerProvider.setCurrentLifecycleOwner(this)
         binding = ActivityEmulatorBinding.inflate(layoutInflater)
@@ -674,6 +680,7 @@ class EmulatorActivity : AppCompatActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        intent.data?.let { uriPermissionManager.tryPersistFilePermissions(it, Permission.READ) }
 
         val launchArgs = LaunchArgs.fromIntent(intent)
         // Invalid arguments. Ignore completely

--- a/app/src/main/java/me/magnum/melonds/utils/FileUtils.kt
+++ b/app/src/main/java/me/magnum/melonds/utils/FileUtils.kt
@@ -76,7 +76,22 @@ object FileUtils {
                 val file = File("/proc/self/fd/${it.fd}")
                 Os.readlink(file.absolutePath)
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Log.d(TAG, "getAbsolutePathFromSingleUri: failed to resolve path for $uri", e)
+            null
+        }
+    }
+
+    // Return the document ID embedded in [uri] without requiring URI permission
+    fun getDocumentIdOrNull(context: Context, uri: Uri): String? {
+        return try {
+            if (DocumentsContract.isDocumentUri(context, uri)) {
+                DocumentsContract.getDocumentId(uri)
+            } else {
+                DocumentsContract.getTreeDocumentId(uri)
+            }
+        } catch (e: Exception) {
+            Log.d(TAG, "getDocumentIdOrNull: failed to parse document id for $uri", e)
             null
         }
     }


### PR DESCRIPTION
## Problem
Launching a ROM into melonDS from an external app (ES-DE in my case) via an explicit Intent with a content:// URI shows "Could not find ROM", even though the same file launches fine from melonDS's own ROM list.

## Root cause
Internal launches hand the emulator an already-resolved Rom object directly, so they never touch URI-matching logic. External launches only provide a bare content:// URI, which goes through FileSystemRomsRepository.getRomAtUri(). That function's matching strategies (findRomByPath, findRomBySize) work by opening the incoming URI via openFileDescriptor to resolve/compare its real path — but the sending app usually holds its own independent SAF permission grant over the ROM, obtained through its own folder picker, separate from melonDS's own persisted grant over the same file. melonDS has no permission on that external grant, so every open attempt throws SecurityException, which is silently swallowed, and every match strategy fails, falling through to a "ROM not found" error.

## Fix
DocumentsContract.getDocumentId() / getTreeDocumentId() are pure string-parsing calls on the URI itself — no IPC, no permission required. This adds a new matching strategy, findRomByDocumentId(), that parses the document ID out of both the incoming URI and each already-scanned ROM's own URI and compares them directly, before ever trying to open the file. If they match, the already-known Rom is returned immediately, bypassing the unpermitted incoming URI entirely.