### PR TITLE
Fix idle power draw while emulator UI is inactive

### DIFF
--- a/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
@@ -166,6 +166,7 @@ class EmulatorActivity : AppCompatActivity() {
 
     private var presentation: ExternalPresentation? = null
     private var isRenderingActive = false
+    private var isResumePending = false
 
     private lateinit var handler: Handler
     private val screenPowerReceiver = object : BroadcastReceiver() {
@@ -173,8 +174,10 @@ class EmulatorActivity : AppCompatActivity() {
             when (intent.action) {
                 Intent.ACTION_SCREEN_OFF -> suspendEmulationForInactiveUi()
                 Intent.ACTION_SCREEN_ON,
-                Intent.ACTION_USER_PRESENT -> handler.post {
-                    maybeResumeEmulationForActiveUi()
+                Intent.ACTION_USER_PRESENT -> {
+                    if (!activeOverlays.hasActiveOverlays()) {
+                        resumeEmulationWhenUiIsReady()
+                    }
                 }
             }
         }
@@ -218,7 +221,7 @@ class EmulatorActivity : AppCompatActivity() {
         }
 
         override fun onPausePressed() {
-            viewModel.pauseEmulator(true)
+            pauseEmulator(true)
         }
 
         override fun onFastForwardPressed() {
@@ -700,7 +703,7 @@ class EmulatorActivity : AppCompatActivity() {
             return
 
         if (viewModel.emulatorState.value.isRunning()) {
-            viewModel.pauseEmulator(false)
+            pauseEmulator(false)
 
             activeOverlays.addActiveOverlay(EmulatorOverlay.SWITCH_NEW_ROM_DIALOG)
             AlertDialog.Builder(this)
@@ -725,7 +728,11 @@ class EmulatorActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        maybeResumeEmulationForActiveUi()
+        if (activeOverlays.hasActiveOverlays()) {
+            handler.post { maybeResumeEmulationForActiveUi() }
+        } else {
+            resumeEmulationWhenUiIsReady()
+        }
     }
 
     private fun maybeResumeEmulationForActiveUi() {
@@ -736,13 +743,15 @@ class EmulatorActivity : AppCompatActivity() {
         viewModel.onActivityResumed()
         startRenderingIfNeeded()
 
-        if (!activeOverlays.hasActiveOverlays()) {
+        if (isResumePending && !activeOverlays.hasActiveOverlays()) {
+            isResumePending = false
             disableScreenTimeOut()
             viewModel.resumeEmulator()
         }
     }
 
     private fun resumeEmulationWhenUiIsReady() {
+        isResumePending = true
         handler.post {
             maybeResumeEmulationForActiveUi()
         }
@@ -882,7 +891,7 @@ class EmulatorActivity : AppCompatActivity() {
         if (isRewindWindowOpen()) {
             closeRewindWindow()
         } else {
-            viewModel.pauseEmulator(true)
+            pauseEmulator(true)
         }
     }
 
@@ -1053,10 +1062,16 @@ class EmulatorActivity : AppCompatActivity() {
     }
 
     private fun suspendEmulationForInactiveUi() {
+        isResumePending = false
         viewModel.onActivityPaused()
         enableScreenTimeOut()
         stopRenderingIfNeeded()
         viewModel.pauseEmulator(false)
+    }
+
+    private fun pauseEmulator(showPauseMenu: Boolean) {
+        isResumePending = false
+        viewModel.pauseEmulator(showPauseMenu)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorActivity.kt
@@ -1,7 +1,10 @@
 package me.magnum.melonds.ui.emulator
 
+import android.app.KeyguardManager
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.res.Configuration
 import android.hardware.display.DisplayManager
 import android.hardware.input.InputManager
@@ -162,8 +165,20 @@ class EmulatorActivity : AppCompatActivity() {
     lateinit var appForegroundStateObserver: AppForegroundStateObserver
 
     private var presentation: ExternalPresentation? = null
+    private var isRenderingActive = false
 
     private lateinit var handler: Handler
+    private val screenPowerReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            when (intent.action) {
+                Intent.ACTION_SCREEN_OFF -> suspendEmulationForInactiveUi()
+                Intent.ACTION_SCREEN_ON,
+                Intent.ACTION_USER_PRESENT -> handler.post {
+                    maybeResumeEmulationForActiveUi()
+                }
+            }
+        }
+    }
     private val displayListener = object : DisplayManager.DisplayListener {
 
         override fun onDisplayAdded(displayId: Int) {
@@ -244,11 +259,11 @@ class EmulatorActivity : AppCompatActivity() {
         viewModel.onSettingsChanged()
         setupSustainedPerformanceMode()
         setupFpsCounter()
-        viewModel.resumeEmulator()
+        resumeEmulationWhenUiIsReady()
     }
     private val cheatsLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         viewModel.onCheatsChanged()
-        viewModel.resumeEmulator()
+        resumeEmulationWhenUiIsReady()
     }
     private val permissionRequestLauncher = registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
         lifecycleScope.launch {
@@ -272,7 +287,9 @@ class EmulatorActivity : AppCompatActivity() {
 
     private val activeOverlays = EmulatorOverlayTracker(
         onOverlaysCleared = {
-            disableScreenTimeOut()
+            if (canUseEmulatorUi()) {
+                disableScreenTimeOut()
+            }
             presentation?.setPauseOverlayVisibility(false)
         },
         onOverlaysPresent = {
@@ -288,6 +305,7 @@ class EmulatorActivity : AppCompatActivity() {
         binding = ActivityEmulatorBinding.inflate(layoutInflater)
         supportRequestWindowFeature(Window.FEATURE_NO_TITLE)
         setContentView(binding.root)
+        registerScreenPowerReceiver()
         setupFullscreen()
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
             val insets = windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout())
@@ -376,7 +394,7 @@ class EmulatorActivity : AppCompatActivity() {
                         viewModel = achievementsViewModel,
                         onDismiss = {
                             activeOverlays.removeActiveOverlay(EmulatorOverlay.ACHIEVEMENTS_DIALOG)
-                            viewModel.resumeEmulator()
+                            resumeEmulationWhenUiIsReady()
                             showAchievementList.value = false
                         }
                     )
@@ -388,7 +406,7 @@ class EmulatorActivity : AppCompatActivity() {
                         onExit = { viewModel.exitEmulator(force = true) },
                         onCancel = {
                             activeOverlays.removeActiveOverlay(EmulatorOverlay.PENDING_SUBMISSION_CONFIRM_EXIT)
-                            viewModel.resumeEmulator()
+                            resumeEmulationWhenUiIsReady()
                             showPendingSubmissionsDialog.value = false
                         }
                     )
@@ -489,7 +507,7 @@ class EmulatorActivity : AppCompatActivity() {
                 viewModel.uiEvent.collectLatest {
                     when (it) {
                         EmulatorUiEvent.CloseEmulator -> {
-                            choreographerFrameRenderer.stopRendering()
+                            stopRenderingIfNeeded()
                             presentation?.dismiss()
                             finish()
                         }
@@ -521,6 +539,7 @@ class EmulatorActivity : AppCompatActivity() {
                             activeOverlays.addActiveOverlay(EmulatorOverlay.PENDING_SUBMISSION_CONFIRM_EXIT)
                             showPendingSubmissionsDialog.value = true
                         }
+                        EmulatorUiEvent.ResumeEmulationWhenReady -> resumeEmulationWhenUiIsReady()
                     }
                 }
             }
@@ -698,7 +717,7 @@ class EmulatorActivity : AppCompatActivity() {
                         activeOverlays.removeActiveOverlay(EmulatorOverlay.SWITCH_NEW_ROM_DIALOG)
                     }
                     .setOnCancelListener {
-                        viewModel.resumeEmulator()
+                        resumeEmulationWhenUiIsReady()
                     }
                     .show()
         }
@@ -706,7 +725,16 @@ class EmulatorActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        choreographerFrameRenderer.startRendering()
+        maybeResumeEmulationForActiveUi()
+    }
+
+    private fun maybeResumeEmulationForActiveUi() {
+        if (!canUseEmulatorUi()) {
+            return
+        }
+
+        viewModel.onActivityResumed()
+        startRenderingIfNeeded()
 
         if (!activeOverlays.hasActiveOverlays()) {
             disableScreenTimeOut()
@@ -714,9 +742,29 @@ class EmulatorActivity : AppCompatActivity() {
         }
     }
 
+    private fun resumeEmulationWhenUiIsReady() {
+        handler.post {
+            maybeResumeEmulationForActiveUi()
+        }
+    }
+
+    private fun canUseEmulatorUi(): Boolean {
+        return lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED) &&
+                hasWindowFocus() &&
+                window.decorView.windowVisibility == View.VISIBLE &&
+                binding.root.isShown &&
+                ContextCompat.getDisplayOrDefault(this).state == Display.STATE_ON &&
+                getSystemService<KeyguardManager>()?.isKeyguardLocked != true
+    }
+
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
         setupFullscreen()
+        if (hasFocus) {
+            handler.post {
+                maybeResumeEmulationForActiveUi()
+            }
+        }
     }
 
     private fun setupFullscreen() {
@@ -854,7 +902,7 @@ class EmulatorActivity : AppCompatActivity() {
                     activeOverlays.removeActiveOverlay(EmulatorOverlay.PAUSE_MENU)
                 }
                 .setOnCancelListener {
-                    viewModel.resumeEmulator()
+                    resumeEmulationWhenUiIsReady()
                 }
                 .show()
     }
@@ -927,7 +975,7 @@ class EmulatorActivity : AppCompatActivity() {
                 activeOverlays.removeActiveOverlay(EmulatorOverlay.SAVE_STATES_DIALOG)
             }
             .setOnCancelListener {
-                viewModel.resumeEmulator()
+                resumeEmulationWhenUiIsReady()
             }
             .show()
     }
@@ -981,7 +1029,7 @@ class EmulatorActivity : AppCompatActivity() {
     private fun closeRewindWindow() {
         activeOverlays.removeActiveOverlay(EmulatorOverlay.REWIND_WINDOW)
         binding.root.transitionToState(R.id.rewind_hidden)
-        viewModel.resumeEmulator()
+        resumeEmulationWhenUiIsReady()
     }
 
     private fun showLoadingState() {
@@ -1001,8 +1049,13 @@ class EmulatorActivity : AppCompatActivity() {
 
     override fun onPause() {
         super.onPause()
+        suspendEmulationForInactiveUi()
+    }
+
+    private fun suspendEmulationForInactiveUi() {
+        viewModel.onActivityPaused()
         enableScreenTimeOut()
-        choreographerFrameRenderer.stopRendering()
+        stopRenderingIfNeeded()
         viewModel.pauseEmulator(false)
     }
 
@@ -1026,7 +1079,31 @@ class EmulatorActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        unregisterReceiver(screenPowerReceiver)
         frameRenderCoordinator.stop()
         presentation?.dismiss()
+    }
+
+    private fun registerScreenPowerReceiver() {
+        val filter = IntentFilter().apply {
+            addAction(Intent.ACTION_SCREEN_OFF)
+            addAction(Intent.ACTION_SCREEN_ON)
+            addAction(Intent.ACTION_USER_PRESENT)
+        }
+        ContextCompat.registerReceiver(this, screenPowerReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+    }
+
+    private fun startRenderingIfNeeded() {
+        if (!isRenderingActive) {
+            choreographerFrameRenderer.startRendering()
+            isRenderingActive = true
+        }
+    }
+
+    private fun stopRenderingIfNeeded() {
+        if (isRenderingActive) {
+            choreographerFrameRenderer.stopRendering()
+            isRenderingActive = false
+        }
     }
 }

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorViewModel.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorViewModel.kt
@@ -1,6 +1,7 @@
 package me.magnum.melonds.ui.emulator
 
 import android.net.Uri
+import android.os.SystemClock
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -116,6 +117,12 @@ class EmulatorViewModel @Inject constructor(
 
     private val sessionCoroutineScope = EmulatorSessionCoroutineScope()
     private var raSessionJob: Job? = null
+    private var isActivityResumed = false
+    private var isEmulationPaused = true
+    private var fpsTrackingJob: Job? = null
+    private var playTimeTrackingJob: Job? = null
+    private var playTimeTrackingRom: Rom? = null
+    private var playTimeTrackingStartMillis: Long? = null
 
     private val _emulatorState = MutableStateFlow<EmulatorState>(EmulatorState.Uninitialized)
     val emulatorState = _emulatorState.asStateFlow()
@@ -263,8 +270,7 @@ class EmulatorViewModel @Inject constructor(
                     _toastEvent.tryEmit(ToastEvent.GbaLoadFailed)
                 }
                 _emulatorState.value = EmulatorState.RunningRom(rom)
-                startTrackingFps()
-                startTrackingPlayTime(rom)
+                onEmulationStarted()
             }
         }
     }
@@ -288,7 +294,7 @@ class EmulatorViewModel @Inject constructor(
                     }
                     FirmwareLaunchResult.LaunchSuccessful -> {
                         _emulatorState.value = EmulatorState.RunningFirmware(consoleType)
-                        startTrackingFps()
+                        onEmulationStarted()
                     }
                 }
             }
@@ -346,7 +352,18 @@ class EmulatorViewModel @Inject constructor(
         }
     }
 
+    fun onActivityResumed() {
+        isActivityResumed = true
+    }
+
+    fun onActivityPaused() {
+        isActivityResumed = false
+    }
+
     fun pauseEmulator(showPauseMenu: Boolean) {
+        isEmulationPaused = true
+        stopActiveSessionTracking(flushPlayTime = true)
+
         sessionCoroutineScope.launch {
             emulatorManager.pauseEmulator()
             if (showPauseMenu) {
@@ -370,8 +387,10 @@ class EmulatorViewModel @Inject constructor(
     }
 
     fun resumeEmulator() {
+        isEmulationPaused = false
         sessionCoroutineScope.launch {
             emulatorManager.resumeEmulator()
+            startActiveSessionTracking()
         }
     }
 
@@ -394,6 +413,7 @@ class EmulatorViewModel @Inject constructor(
     }
 
     private fun stopEmulator() {
+        stopActiveSessionTracking(flushPlayTime = true)
         viewModelScope.launch {
             _achievementsEvent.emit(RAEventUi.Reset)
         }
@@ -402,20 +422,9 @@ class EmulatorViewModel @Inject constructor(
     }
 
     private fun stopEmulatorAndExit() {
+        stopActiveSessionTracking(flushPlayTime = true)
         emulatorManager.stopEmulator()
         _uiEvent.tryEmit(EmulatorUiEvent.CloseEmulator)
-    }
-
-    private fun startTrackingPlayTime(rom: Rom) {
-        sessionCoroutineScope.launch {
-            var lastTime = System.currentTimeMillis()
-            while (isActive) {
-                delay(1000)
-                val now = System.currentTimeMillis()
-                romsRepository.addRomPlayTime(rom, (now - lastTime).milliseconds)
-                lastTime = now
-            }
-        }
     }
 
     fun onPauseMenuOptionSelected(option: PauseMenuOption) {
@@ -496,7 +505,7 @@ class EmulatorViewModel @Inject constructor(
                 if (!saveRomState(it.rom, slot)) {
                     _toastEvent.emit(ToastEvent.StateSaveFailed)
                 }
-                emulatorManager.resumeEmulator()
+                _uiEvent.emit(EmulatorUiEvent.ResumeEmulationWhenReady)
             }
         }
     }
@@ -510,7 +519,7 @@ class EmulatorViewModel @Inject constructor(
                     if (!loadRomState(it.rom, slot)) {
                         _toastEvent.emit(ToastEvent.StateLoadFailed)
                     }
-                    emulatorManager.resumeEmulator()
+                    _uiEvent.emit(EmulatorUiEvent.ResumeEmulationWhenReady)
                 }
             }
         }
@@ -526,7 +535,7 @@ class EmulatorViewModel @Inject constructor(
                     if (saveRomState(currentState.rom, quickSlot)) {
                         _toastEvent.emit(ToastEvent.QuickSaveSuccessful)
                     }
-                    emulatorManager.resumeEmulator()
+                    _uiEvent.emit(EmulatorUiEvent.ResumeEmulationWhenReady)
                 }
             }
             is EmulatorState.RunningFirmware -> {
@@ -549,7 +558,7 @@ class EmulatorViewModel @Inject constructor(
                         if (loadRomState(currentState.rom, quickSlot)) {
                             _toastEvent.emit(ToastEvent.QuickLoadSuccessful)
                         }
-                        emulatorManager.resumeEmulator()
+                        _uiEvent.emit(EmulatorUiEvent.ResumeEmulationWhenReady)
                     }
                 } else {
                     _toastEvent.tryEmit(ToastEvent.CannotUseSaveStatesWhenRAHardcoreIsEnabled)
@@ -638,9 +647,11 @@ class EmulatorViewModel @Inject constructor(
     }
 
     private fun resetEmulatorState(newState: EmulatorState) {
+        stopActiveSessionTracking(flushPlayTime = true)
         sessionCoroutineScope.notifyNewSessionStarted()
         emulatorSession.reset()
         raSessionJob = null
+        isEmulationPaused = true
         _currentFps.value = null
         _emulatorState.value = newState
         _mainScreenBackground.value = RuntimeBackground.None
@@ -981,13 +992,91 @@ class EmulatorViewModel @Inject constructor(
         }
     }
 
-    private fun startTrackingFps() {
-        sessionCoroutineScope.launch {
+    private suspend fun onEmulationStarted() {
+        isEmulationPaused = !isActivityResumed
+        if (isEmulationPaused) {
+            emulatorManager.pauseEmulator()
+        } else {
+            startActiveSessionTracking()
+        }
+    }
+
+    private fun startActiveSessionTracking() {
+        if (!isActivityResumed || isEmulationPaused) {
+            return
+        }
+
+        when (val state = _emulatorState.value) {
+            is EmulatorState.RunningRom -> {
+                startFpsTracking()
+                startPlayTimeTracking(state.rom)
+            }
+            is EmulatorState.RunningFirmware -> startFpsTracking()
+            else -> { /* Do nothing */ }
+        }
+    }
+
+    private fun stopActiveSessionTracking(flushPlayTime: Boolean) {
+        stopFpsTracking()
+        stopPlayTimeTracking(flushPlayTime)
+    }
+
+    private fun startFpsTracking() {
+        if (fpsTrackingJob?.isActive == true) {
+            return
+        }
+
+        fpsTrackingJob = sessionCoroutineScope.launch {
             while (isActive) {
                 delay(1.seconds)
                 _currentFps.value = emulatorManager.getFps().roundToInt()
             }
         }
+    }
+
+    private fun stopFpsTracking() {
+        fpsTrackingJob?.cancel()
+        fpsTrackingJob = null
+        _currentFps.value = null
+    }
+
+    private fun startPlayTimeTracking(rom: Rom) {
+        if (playTimeTrackingJob?.isActive == true && playTimeTrackingRom?.hasSameFileAsRom(rom) == true) {
+            return
+        }
+
+        stopPlayTimeTracking(flushPlayTime = true)
+        playTimeTrackingRom = rom
+        playTimeTrackingStartMillis = SystemClock.elapsedRealtime()
+        playTimeTrackingJob = sessionCoroutineScope.launch {
+            while (isActive) {
+                delay(1.minutes)
+                flushPlayTime()
+            }
+        }
+    }
+
+    private fun stopPlayTimeTracking(flushPlayTime: Boolean) {
+        if (flushPlayTime) {
+            flushPlayTime()
+        }
+        playTimeTrackingJob?.cancel()
+        playTimeTrackingJob = null
+        playTimeTrackingRom = null
+        playTimeTrackingStartMillis = null
+    }
+
+    private fun flushPlayTime() {
+        val rom = playTimeTrackingRom ?: return
+        val startMillis = playTimeTrackingStartMillis ?: return
+        val now = SystemClock.elapsedRealtime()
+        val elapsedMillis = now - startMillis
+        if (elapsedMillis <= 0L) {
+            return
+        }
+
+        romsRepository.addRomPlayTime(rom, elapsedMillis.milliseconds)
+        playTimeTrackingStartMillis = now
     }
 
     private fun filterRomPauseMenuOption(option: RomPauseMenuOption): Boolean {

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorViewModel.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/EmulatorViewModel.kt
@@ -399,6 +399,7 @@ class EmulatorViewModel @Inject constructor(
             sessionCoroutineScope.launch {
                 emulatorManager.resetEmulator()
                 _achievementsEvent.emit(RAEventUi.Reset)
+                _uiEvent.emit(EmulatorUiEvent.ResumeEmulationWhenReady)
             }
         }
     }

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/model/EmulatorUiEvent.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/model/EmulatorUiEvent.kt
@@ -19,5 +19,6 @@ sealed class EmulatorUiEvent {
     }
     data object ShowAchievementList : EmulatorUiEvent()
     data object ShowPendingSubmissionsDialog : EmulatorUiEvent()
+    data object ResumeEmulationWhenReady : EmulatorUiEvent()
     data object CloseEmulator : EmulatorUiEvent()
 }


### PR DESCRIPTION
- Gate emulator resume/rendering on active, visible, unlocked UI state.
- Stop rendering and FPS/play-time tracking while paused or inactive.
- Route save/load completion through the same resume-when-ready UI event.

Tested on the AYN Thor