### PR TITLE
Fix stuck touch controls and restore sound after unmuting

### DIFF
--- a/app/src/androidTest/java/me/magnum/melonds/ui/emulator/input/TouchCancellationTest.kt
+++ b/app/src/androidTest/java/me/magnum/melonds/ui/emulator/input/TouchCancellationTest.kt
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package me.magnum.melonds.ui.emulator.input
+
+import android.content.Context
+import android.os.SystemClock
+import android.view.MotionEvent
+import android.view.InputDevice
+import android.view.HapticFeedbackConstants
+import android.view.View
+import android.widget.FrameLayout
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import me.magnum.melonds.common.vibration.TouchVibrator
+import me.magnum.melonds.common.vibration.VibratorDelegate
+import me.magnum.melonds.domain.model.Input
+import me.magnum.melonds.domain.model.Point
+import me.magnum.melonds.domain.repositories.SettingsRepository
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.reflect.Proxy
+
+/** Real Android events, views and production handlers; no ROM or emulator session. */
+@RunWith(AndroidJUnit4::class)
+class TouchCancellationTest {
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val context: Context get() = instrumentation.targetContext
+    private var gestureDownTime = 0L
+
+    @Test
+    fun singleButtonReleasesOnCancel() = onMain {
+        val listener = RecordingListener()
+        val view = feedbackView(SingleButtonInputHandler(listener, Input.L, true, unusedVibrator()))
+        dispatch(view, MotionEvent.ACTION_DOWN)
+        dispatch(view, MotionEvent.ACTION_CANCEL)
+        assertEquals(listOf("down:L", "up:L"), listener.events)
+        assertEquals(listOf(HapticFeedbackConstants.LONG_PRESS), view.feedback)
+    }
+
+    @Test
+    fun touchscreenReleasesOnCancel() = onMain {
+        val listener = RecordingListener()
+        val view = inputView(TouchscreenInputHandler(listener))
+        dispatch(view, MotionEvent.ACTION_DOWN)
+        dispatch(view, MotionEvent.ACTION_CANCEL)
+        assertEquals(listOf("down:TOUCHSCREEN", "touch:128,96", "up:TOUCHSCREEN"), listener.events)
+    }
+
+    @Test
+    fun singleButtonStillReleasesOnUp() = onMain {
+        val listener = RecordingListener()
+        val view = feedbackView(SingleButtonInputHandler(listener, Input.L, true, unusedVibrator()))
+        dispatch(view, MotionEvent.ACTION_DOWN)
+        dispatch(view, MotionEvent.ACTION_MOVE)
+        dispatch(view, MotionEvent.ACTION_UP)
+        assertEquals(listOf("down:L", "up:L"), listener.events)
+        assertEquals(listOf(HapticFeedbackConstants.LONG_PRESS, HapticFeedbackConstants.CLOCK_TICK), view.feedback)
+    }
+
+    @Test
+    fun touchscreenStillMovesAndReleasesOnUp() = onMain {
+        val listener = RecordingListener()
+        val view = inputView(TouchscreenInputHandler(listener))
+        dispatch(view, MotionEvent.ACTION_DOWN)
+        dispatch(view, MotionEvent.ACTION_MOVE, 64f, 48f)
+        dispatch(view, MotionEvent.ACTION_UP, 64f, 48f)
+        assertEquals(listOf("down:TOUCHSCREEN", "touch:128,96", "touch:64,48", "up:TOUCHSCREEN"), listener.events)
+    }
+
+    @Test
+    fun dpadStillReleasesOnCancel() = onMain {
+        val listener = RecordingListener()
+        val view = inputView(DpadInputHandler(listener, false, unusedVibrator()), 512, 512)
+        dispatch(view, MotionEvent.ACTION_DOWN, 480f, 256f)
+        dispatch(view, MotionEvent.ACTION_CANCEL, 480f, 256f)
+        assertEquals(listOf("down:RIGHT", "up:RIGHT"), listener.events)
+    }
+
+    @Test
+    fun touchscreenAcceptsFreshGestureAfterCancel() = onMain {
+        val listener = RecordingListener()
+        val view = inputView(TouchscreenInputHandler(listener))
+        dispatch(view, MotionEvent.ACTION_DOWN)
+        dispatch(view, MotionEvent.ACTION_CANCEL)
+        dispatch(view, MotionEvent.ACTION_DOWN, 64f, 48f)
+        dispatch(view, MotionEvent.ACTION_UP, 64f, 48f)
+        assertEquals(listOf("down:TOUCHSCREEN", "touch:128,96", "up:TOUCHSCREEN", "down:TOUCHSCREEN", "touch:64,48", "up:TOUCHSCREEN"), listener.events)
+    }
+
+    @Test
+    fun interceptedButtonGestureReleasesWithoutAnUpEvent() = onMain {
+        val listener = RecordingListener()
+        val child = inputView(SingleButtonInputHandler(listener, Input.L, false, unusedVibrator()))
+        interceptGesture(child)
+        assertEquals(listOf("down:L", "up:L"), listener.events)
+    }
+
+    @Test
+    fun interceptedTouchscreenGestureReleasesWithoutAnUpEvent() = onMain {
+        val listener = RecordingListener()
+        val child = inputView(TouchscreenInputHandler(listener))
+        interceptGesture(child)
+        assertEquals(listOf("down:TOUCHSCREEN", "touch:128,96", "up:TOUCHSCREEN"), listener.events)
+    }
+
+    @Test
+    fun touchscreenKeepsAveragingMultiplePointersUntilFinalUp() = onMain {
+        val listener = RecordingListener()
+        val view = inputView(TouchscreenInputHandler(listener), 512, 384)
+        dispatchPointers(view, MotionEvent.ACTION_DOWN, 64f to 48f)
+        dispatchPointers(view, MotionEvent.ACTION_POINTER_DOWN or (1 shl MotionEvent.ACTION_POINTER_INDEX_SHIFT), 64f to 48f, 448f to 336f)
+        dispatchPointers(view, MotionEvent.ACTION_MOVE, 64f to 48f, 448f to 336f)
+        dispatchPointers(view, MotionEvent.ACTION_POINTER_UP or (1 shl MotionEvent.ACTION_POINTER_INDEX_SHIFT), 64f to 48f, 448f to 336f)
+        dispatchPointers(view, MotionEvent.ACTION_MOVE, 64f to 48f)
+        dispatchPointers(view, MotionEvent.ACTION_UP, 64f to 48f)
+        assertEquals(listOf("down:TOUCHSCREEN", "touch:32,24", "touch:128,96", "touch:32,24", "up:TOUCHSCREEN"), listener.events)
+    }
+
+    @Test
+    fun touchscreenReleasesAllPointersOnCancel() = onMain {
+        val listener = RecordingListener()
+        val view = inputView(TouchscreenInputHandler(listener))
+        dispatchPointers(view, MotionEvent.ACTION_DOWN, 32f to 24f)
+        dispatchPointers(view, MotionEvent.ACTION_POINTER_DOWN or (1 shl MotionEvent.ACTION_POINTER_INDEX_SHIFT), 32f to 24f, 224f to 168f)
+        dispatchPointers(view, MotionEvent.ACTION_MOVE, 32f to 24f, 224f to 168f)
+        dispatchPointers(view, MotionEvent.ACTION_CANCEL, 32f to 24f, 224f to 168f)
+        assertEquals(listOf("down:TOUCHSCREEN", "touch:32,24", "touch:128,96", "up:TOUCHSCREEN"), listener.events)
+    }
+
+    @Test
+    fun touchscreenStillClampsCoordinatesToDsBounds() = onMain {
+        val listener = RecordingListener()
+        val view = inputView(TouchscreenInputHandler(listener))
+        dispatch(view, MotionEvent.ACTION_DOWN, -10f, -10f)
+        dispatch(view, MotionEvent.ACTION_MOVE, 300f, 200f)
+        dispatch(view, MotionEvent.ACTION_UP, 300f, 200f)
+        assertEquals(listOf("down:TOUCHSCREEN", "touch:0,0", "touch:255,191", "up:TOUCHSCREEN"), listener.events)
+    }
+
+    @Test
+    fun singleButtonIgnoresSecondaryPointerTransitionsUntilFinalUp() = onMain {
+        val listener = RecordingListener()
+        val view = inputView(SingleButtonInputHandler(listener, Input.L, false, unusedVibrator()))
+        dispatchPointers(view, MotionEvent.ACTION_DOWN, 32f to 24f)
+        dispatchPointers(view, MotionEvent.ACTION_POINTER_DOWN or (1 shl MotionEvent.ACTION_POINTER_INDEX_SHIFT), 32f to 24f, 224f to 168f)
+        dispatchPointers(view, MotionEvent.ACTION_POINTER_UP or (1 shl MotionEvent.ACTION_POINTER_INDEX_SHIFT), 32f to 24f, 224f to 168f)
+        dispatchPointers(view, MotionEvent.ACTION_UP, 32f to 24f)
+        assertEquals(listOf("down:L", "up:L"), listener.events)
+    }
+
+    private fun dispatchPointers(view: View, action: Int, vararg coordinates: Pair<Float, Float>) {
+        val properties = Array(coordinates.size) { index -> MotionEvent.PointerProperties().apply { id = index; toolType = MotionEvent.TOOL_TYPE_FINGER } }
+        val positions = Array(coordinates.size) { index -> MotionEvent.PointerCoords().apply { x = coordinates[index].first; y = coordinates[index].second; pressure = 1f; size = 1f } }
+        val now = SystemClock.uptimeMillis()
+        if (action == MotionEvent.ACTION_DOWN) gestureDownTime = now
+        val event = MotionEvent.obtain(gestureDownTime, now, action, coordinates.size, properties, positions, 0, 0, 1f, 1f, 0, 0, InputDevice.SOURCE_TOUCHSCREEN, 0)
+        try {
+            assertTrue("Event $action was not consumed", view.dispatchTouchEvent(event))
+        } finally {
+            event.recycle()
+        }
+    }
+
+    private fun onMain(block: () -> Unit) = instrumentation.runOnMainSync(block)
+
+    private class FeedbackView(context: Context) : View(context) {
+        val feedback = mutableListOf<Int>()
+        override fun performHapticFeedback(feedbackConstant: Int): Boolean {
+            feedback += feedbackConstant
+            return true
+        }
+    }
+
+    private fun feedbackView(handler: View.OnTouchListener) = FeedbackView(context).apply {
+        layout(0, 0, 256, 192)
+        setOnTouchListener(handler)
+    }
+
+    private fun inputView(handler: View.OnTouchListener, width: Int = 256, height: Int = 192): View {
+        return View(context).apply {
+            layout(0, 0, width, height)
+            setOnTouchListener(handler)
+        }
+    }
+
+    private fun interceptGesture(child: View) {
+        val parent = object : FrameLayout(context) {
+            override fun onInterceptTouchEvent(event: MotionEvent): Boolean = event.actionMasked == MotionEvent.ACTION_MOVE
+            override fun onTouchEvent(event: MotionEvent): Boolean = true
+        }
+        parent.addView(child, FrameLayout.LayoutParams(256, 192))
+        parent.layout(0, 0, 256, 192)
+        child.layout(0, 0, 256, 192)
+        dispatch(parent, MotionEvent.ACTION_DOWN)
+        // ViewGroup generates ACTION_CANCEL for the child when it intercepts this move.
+        // No ACTION_UP is sent by the test.
+        dispatch(parent, MotionEvent.ACTION_MOVE)
+    }
+
+    private fun dispatch(view: View, action: Int, x: Float = 128f, y: Float = 96f) {
+        val eventTime = SystemClock.uptimeMillis()
+        if (action == MotionEvent.ACTION_DOWN) gestureDownTime = eventTime
+        val event = MotionEvent.obtain(gestureDownTime, eventTime, action, x, y, 0)
+        try {
+            assertTrue("Event $action was not consumed", view.dispatchTouchEvent(event))
+        } finally {
+            event.recycle()
+        }
+    }
+
+    private class RecordingListener : IInputListener {
+        val events = mutableListOf<String>()
+        override fun onKeyPress(key: Input) { events += "down:$key" }
+        override fun onKeyReleased(key: Input) { events += "up:$key" }
+        override fun onTouch(point: Point) { events += "touch:${point.x},${point.y}" }
+    }
+
+    private fun unusedVibrator(): TouchVibrator {
+        // The constructor requires these dependencies, but handlers use View haptics.
+        // Fail if a future change unexpectedly accesses settings or vibration.
+        val settings = Proxy.newProxyInstance(SettingsRepository::class.java.classLoader, arrayOf(SettingsRepository::class.java)) { _, method, _ ->
+            error("Unexpected settings access: ${method.name}")
+        } as SettingsRepository
+        val delegate = object : VibratorDelegate {
+            override fun supportsVibration(): Boolean = error("Unexpected vibration query")
+            override fun supportsVibrationAmplitude(): Boolean = error("Unexpected amplitude query")
+            override fun vibrate(duration: Int, amplitude: Int) = error("Unexpected vibration")
+            override fun startVibrating() = error("Unexpected vibration")
+            override fun stopVibrating() = error("Unexpected vibration")
+        }
+        return TouchVibrator(delegate, settings)
+    }
+}

--- a/app/src/main/cpp/MelonDSAudio.cpp
+++ b/app/src/main/cpp/MelonDSAudio.cpp
@@ -253,7 +253,7 @@ namespace MelonDSAndroid
 
     void updateAudioSettings(AudioSettings audioSettings)
     {
-        if (audioSettings.soundEnabled && currentAudioSettings.volume > 0) {
+        if (audioSettings.soundEnabled && audioSettings.volume > 0) {
             if (!audioStream) {
                 setupAudioOutputStream(audioSettings.audioLatency, audioSettings.volume);
             } else if (currentAudioSettings.audioLatency != audioSettings.audioLatency || currentAudioSettings.volume != audioSettings.volume) {

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/input/SingleButtonInputHandler.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/input/SingleButtonInputHandler.kt
@@ -16,6 +16,10 @@ class SingleButtonInputHandler(inputListener: IInputListener, private val input:
                 inputListener.onKeyReleased(input)
                 performHapticFeedback(v, HapticFeedbackType.KEY_RELEASE)
             }
+            MotionEvent.ACTION_CANCEL -> {
+                // A cancelled gesture ends without a subsequent ACTION_UP.
+                inputListener.onKeyReleased(input)
+            }
         }
         return true
     }

--- a/app/src/main/java/me/magnum/melonds/ui/emulator/input/TouchscreenInputHandler.kt
+++ b/app/src/main/java/me/magnum/melonds/ui/emulator/input/TouchscreenInputHandler.kt
@@ -21,7 +21,7 @@ class TouchscreenInputHandler(inputListener: IInputListener) : BaseInputHandler(
             MotionEvent.ACTION_MOVE -> {
                 inputListener.onTouch(normalizeTouchCoordinates(event, v.width, v.height))
             }
-            MotionEvent.ACTION_UP -> {
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                 inputListener.onKeyReleased(Input.TOUCHSCREEN)
                 onScreenRelease()
             }


### PR DESCRIPTION
This PR fixes two problems:

- **Touch controls can stay pressed after an interrupted gesture.** The app now releases the on-screen button or DS touchscreen when Android cancels the gesture. Normal release behavior is preserved.
- **Sound can fail to return after raising the app volume from zero.** The app used the previous volume to decide whether audio output should be open. It now uses the newly selected volume, so muting and restoring the volume update audio output correctly.

Both fixes were tested together, before and after, in an Android 13 emulator on a Mac. The same test package was used for both builds.

| Check | Before | After |
|---|---|---|
| Touch cancellation, including the input state seen by the emulated DS | 10 failures in 18 tests | All 18 pass |
| Audio changes, pause/resume and restart | The same 5 failures in each of three runs | All 54 checks pass |

The 13 existing automated code tests also pass. Audio checks verify that output actually opens and writes audio data.

[Reproduction steps, test sources and recorded results](https://github.com/Umberto-DEV/melonDS-android/tree/0c6ca0c1a1e634e16d306de5a41ae385168d12a0/validation/combined-regression) include the exact source versions, build commands and checks to repeat.

**This PR does not include an input-lag optimization.** A separate [1,600-event comparison](https://github.com/Umberto-DEV/melonDS-android/blob/0c6ca0c1a1e634e16d306de5a41ae385168d12a0/validation/input-response/REPORT.md) found no repeatable improvement from an experimental rendering change, so that change is excluded. No battery-life improvement is claimed.

The audio fix from #1668 is included here so both fixes can be reviewed in one PR.
