### PR TITLE
Restore audio when raising the volume from zero

### DIFF
--- a/app/src/main/cpp/MelonDSAudio.cpp
+++ b/app/src/main/cpp/MelonDSAudio.cpp
@@ -253,7 +253,7 @@ namespace MelonDSAndroid
 
     void updateAudioSettings(AudioSettings audioSettings)
     {
-        if (audioSettings.soundEnabled && currentAudioSettings.volume > 0) {
+        if (audioSettings.soundEnabled && audioSettings.volume > 0) {
             if (!audioStream) {
                 setupAudioOutputStream(audioSettings.audioLatency, audioSettings.volume);
             } else if (currentAudioSettings.audioLatency != audioSettings.audioLatency || currentAudioSettings.volume != audioSettings.volume) {


### PR DESCRIPTION
Raising the in-app volume from zero can leave audio silent until another settings update. `updateAudioSettings()` decides whether to keep an output stream using the previous volume: applying zero recreates a silent stream, and the next positive update closes it. Check the incoming volume instead, while retaining the existing old/new comparisons that decide when to recreate a stream.

The affected sequence is: run with sound enabled, set the in-app volume to zero and resume, then raise it and resume. The first positive update should restore output. This is separate from #1625's mute-on-fast-forward setting, whose current diff retains the old-volume condition.

Validated at app `3f3a1c8` / core `431ab4bd` through the production `MelonEmulator` JNI API on an Android 13 ARM64 AVD, using an original silent synthetic guest and real Oboe 1.10.0 / AAudio output. Three baseline processes each reproduce the same five failing observations out of 18; three patched processes pass all 18 each. The patched zero-to-positive transition reaches `Started` with increasing frames written at 48 kHz stereo. Checks also cover ordinary mute, repeated settings, pause, an update while paused, resume, stop, and reopening.

The observer is test-only and queries pending Oboe transitions with `waitForStateChange(..., 0)`; it never requests a start, pause, or stop. The same observer and byte-identical instrumentation APK were used for both variants. The only differing app APK payload is the native frontend library. The separate macOS decision harness also changes from three expected failures to eight passing checks; it uses fake Oboe and is not the Android stream evidence.

The guest has no music, so this verifies stream creation and lifecycle rather than audibility, sound quality, Bluetooth behavior, physical-device latency, or energy use. The Activity/settings UI was not automated. The AVD used SwiftShader with host audio enabled; emulated radio backends were disabled after a host Netsim fault in a separate test. The patch submitted here is the single production-line change.

[Reproduction instructions, test sources and selected results](https://github.com/Umberto-DEV/melonDS-android/tree/83e1841be92b4350c5863d55d18545b0eef702ca/validation/audio-volume). The linked proof commit contains only original test sources and textual results; no APKs, personal ROMs, saves or device logs.
